### PR TITLE
Phase 12: Phase 11マージ後の不具合修正・調査・ドキュメント統一

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -318,6 +318,7 @@ sequenceDiagram
 **レスポンス（200）**:
 ```json
 {
+  "message": "Login successful",
   "session_id": "uuid",
   "expires_at": "2025-12-08T12:00:00Z"
 }
@@ -336,7 +337,7 @@ sequenceDiagram
 **レスポンス（200）**:
 ```json
 {
-  "message": "Logged out successfully"
+  "message": "Logout successful"
 }
 ```
 
@@ -380,9 +381,14 @@ sequenceDiagram
 **レスポンス（201）**:
 ```json
 {
-  "id": "uuid",
-  "name": "repo-name",
-  "path": "/path/to/git/repo"
+  "project": {
+    "id": "uuid",
+    "name": "repo-name",
+    "path": "/path/to/git/repo",
+    "default_model": "auto",
+    "run_scripts": [],
+    "created_at": "2025-12-01T00:00:00Z"
+  }
 }
 ```
 
@@ -417,6 +423,22 @@ sequenceDiagram
   "run_scripts": [
     {"name": "test", "command": "npm test"}
   ]
+}
+```
+
+**レスポンス（200）**:
+```json
+{
+  "project": {
+    "id": "uuid",
+    "name": "repo-name",
+    "path": "/path/to/git/repo",
+    "default_model": "sonnet",
+    "run_scripts": [
+      {"name": "test", "command": "npm test"}
+    ],
+    "created_at": "2025-12-01T00:00:00Z"
+  }
 }
 ```
 
@@ -509,18 +531,50 @@ sequenceDiagram
 }
 ```
 
+**レスポンス（200）**:
+```json
+{
+  "id": "msg-uuid",
+  "role": "user",
+  "content": "Please also add tests",
+  "timestamp": "2025-12-08T10:05:00Z"
+}
+```
+
 #### POST /api/sessions/{id}/approve
 **目的**: 権限承認
 
 **リクエスト**:
 ```json
 {
-  "approved": true
+  "action": "approve",
+  "permission_id": "perm-uuid"
+}
+```
+
+**レスポンス（200）**:
+```json
+{
+  "success": true,
+  "action": "approve"
 }
 ```
 
 #### POST /api/sessions/{id}/stop
 **目的**: セッション停止
+
+**レスポンス（200）**:
+```json
+{
+  "id": "uuid",
+  "name": "feature-auth",
+  "status": "stopped",
+  "git_status": "dirty",
+  "model": "sonnet",
+  "worktree_path": "/path/to/worktree",
+  "created_at": "2025-12-08T10:00:00Z"
+}
+```
 
 #### DELETE /api/sessions/{id}
 **目的**: セッション削除（worktreeも削除）
@@ -595,6 +649,8 @@ sequenceDiagram
 #### POST /api/sessions/{id}/reset
 **目的**: 特定コミットへのリセット
 
+**注意**: このエンドポイントは未実装です。
+
 **リクエスト**:
 ```json
 {
@@ -613,10 +669,27 @@ sequenceDiagram
 }
 ```
 
+**レスポンス（200）**:
+```json
+{
+  "success": true
+}
+```
+
+**レスポンス（409）**:
+```json
+{
+  "success": false,
+  "conflicts": ["src/auth.ts", "src/utils.ts"]
+}
+```
+
 ### ランスクリプト
 
 #### POST /api/sessions/{id}/run
 **目的**: ランスクリプト実行
+
+**注意**: このエンドポイントは未実装です。
 
 **リクエスト**:
 ```json
@@ -635,10 +708,14 @@ sequenceDiagram
 #### POST /api/sessions/{id}/run/{run_id}/stop
 **目的**: ランスクリプト停止
 
+**注意**: このエンドポイントは未実装です。
+
 ### プロンプト履歴
 
 #### GET /api/prompts
 **目的**: プロンプト履歴取得
+
+**注意**: このエンドポイントは未実装です。
 
 **レスポンス（200）**:
 ```json
@@ -656,6 +733,8 @@ sequenceDiagram
 
 #### DELETE /api/prompts/{id}
 **目的**: プロンプト履歴削除
+
+**注意**: このエンドポイントは未実装です。
 
 ## WebSocket API
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

Phase 11マージ後の不具合調査と設計書のドキュメント統一を実施しました。セッション作成エラーの原因を特定し、Dialogキャンセルボタンの動作を検証し、APIレスポンス形式の設計書を実装に合わせて統一しました。

## 変更内容

### タスク12.1: セッション作成エラーの原因調査（Critical）

**コミット**: `267e7cc`

**発見された問題**:
- 環境変数`DATABASE_URL`が開発サーバー起動時に設定されていない
- `/Users/tsk/Sync/git/claude-work/src/lib/db.ts`の4-5行目で、`DATABASE_URL`が未設定の場合にテスト用データベース`file:./data/test.db`をデフォルト値として設定している
- このテスト用データベースは読み取り専用になっており、セッション作成時の書き込みが失敗

**確認事項**:
- ✅ エラーログをブラウザDevToolsで確認
- ✅ ProcessManagerのエラーハンドリング（100-114行目）は正しく実装されている
- ✅ 環境変数CLAUDE_CODE_PATHはデフォルト値`'claude'`を使用
- ✅ Claude Code実行可能性を確認（バージョン2.0.72）
- ✅ データベースファイル権限を確認

**修正方針**:
1. `.env`ファイルに`DATABASE_URL=file:./prisma/data/claudework.db`を明示的に設定する
2. `server.ts`で`dotenv/config`をインポートする前に`db.ts`が読み込まれないよう、インポート順序を確認する
3. `src/lib/db.ts`のデフォルト値設定を開発環境では無効化し、`.env`の設定を必須とする

### タスク12.2: Dialogキャンセルボタンの実ブラウザ確認（Medium）

**コミット**: `54d45fe`

**検証結果**:
- Chrome DevToolsを使用した実ブラウザ環境でテストを実施
- **問題を確認**: キャンセルボタンのクリックで5秒後にタイムアウトエラーが発生
- **重要な発見**: DevTools特有の問題ではなく、実際のアプリケーションの問題
- **正常動作**: Escキーでは即座にDialogが閉じる

**該当コード**:
- `/Users/tsk/Sync/git/claude-work/src/components/projects/AddProjectModal.tsx:123`
- キャンセルボタンのクリックイベントハンドリングに問題がある可能性

**次のステップ**:
- キャンセルボタンのクリックイベントハンドリングの原因調査と修正が必要

### タスク12.3: 設計書APIレスポンス形式の全体統一（Low）

**コミット**: `af861b8`

**更新内容**:
- **認証API**: 
  - POST /api/auth/login に `message` フィールドを追加
  - POST /api/auth/logout のメッセージを "Logged out successfully" → "Logout successful" に修正
- **プロジェクトAPI**: 
  - POST /api/projects を `{ project: {...} }` 形式に変更（Phase 11の実装に合わせる）
  - PUT /api/projects/{id} のレスポンス例を追加
- **セッションAPI**: 
  - POST /api/sessions/{id}/input のレスポンス例を追加
  - POST /api/sessions/{id}/approve のリクエストとレスポンス例を修正
  - POST /api/sessions/{id}/stop のレスポンス例を追加
- **Git操作API**: 
  - POST /api/sessions/{id}/merge のレスポンス例を追加（200, 409）
  - POST /api/sessions/{id}/reset に「未実装」の注意書きを追加
- **ランスクリプトAPI**: 未実装の注意書きを追加
- **プロンプト履歴API**: 未実装の注意書きを追加

**統一方針**（Phase 11で確立）:
- GETエンドポイント: `{ リソース名（複数形）: [...] }`
- POST/PUTエンドポイント: `{ リソース名（単数形）: {...} }`
- 一括作成エンドポイント: `{ リソース名（複数形）: [...] }`

## テスト状況

- タスク12.1: 調査完了、原因特定済み
- タスク12.2: 実ブラウザ検証完了、問題確認済み
- タスク12.3: ドキュメント更新完了

## 統計

- **総コミット数**: 3コミット
- **変更ファイル数**: 1ファイル（docs/design.md）
- **追加行数**: +84行
- **削除行数**: -5行

## 関連Issue/タスク

- docs/tasks/phase12.md の全タスク完了
- 参照: docs/verification-report-phase11-post-merge.md

## 確認事項

- [x] タスク12.1: セッション作成エラーの原因を特定し、修正方針を提案
- [x] タスク12.2: Dialogキャンセルボタンの動作確認完了、問題の有無を判別
- [x] タスク12.3: docs/design.mdのすべてのAPIレスポンス形式が実装と一致
- [x] 各タスクのコミットメッセージがConventional Commitsに従っている
- [x] 調査・確認結果が適切に記録されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* **Documentation**
  * API レスポンスに詳細なメッセージフィールドを追加
  * プロジェクト操作レスポンスを拡張し、より詳細なメタデータを含むように更新
  * セッションおよびプロンプトエンドポイントのレスポンスペイロードを充実
  * 一部の未実装エンドポイントをドキュメントに明記

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->