### PR TITLE
fix: npx実行時にローカルのPrisma/pm2バージョンを使用するよう修正

### DIFF
--- a/docs/sdd-npx-prisma-fix/design.md
+++ b/docs/sdd-npx-prisma-fix/design.md
@@ -1,0 +1,110 @@
+# 設計: npx 実行時の依存バージョン不整合修正
+
+> このドキュメントはAIエージェント（Claude Code等）が実装を行うことを前提としています。
+
+## 情報の明確性チェック
+
+### ユーザーから明示された情報
+
+- [x] 問題: `npx prisma` がグローバル Prisma 7.x を使用
+- [x] 解決策: node_modules 内のバイナリを直接使用
+
+### 不明/要確認の情報
+
+なし
+
+---
+
+## アーキテクチャ概要
+
+```text
+修正前:
+┌─────────────────────────────────────────────────────────────┐
+│  npx prisma generate                                         │
+│       ↓                                                      │
+│  グローバル Prisma (7.x) を使用 → エラー                     │
+└─────────────────────────────────────────────────────────────┘
+
+修正後:
+┌─────────────────────────────────────────────────────────────┐
+│  node_modules/.bin/prisma generate                           │
+│       ↓                                                      │
+│  ローカル Prisma (5.22.0) を使用 → 成功                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## コンポーネント
+
+### コンポーネント1: package.json (prepare スクリプト)
+
+**目的**: ビルド時に正しい Prisma バージョンを使用
+
+**変更内容**:
+```json
+{
+  "scripts": {
+    "prepare": "prisma generate && DATABASE_URL=file:./data/build.db npm run build"
+  }
+}
+```
+
+**理由**:
+- `npx prisma` → `prisma` に変更
+- npm scripts 内では node_modules/.bin が PATH に含まれるため、ローカルの prisma が使用される
+
+### コンポーネント2: src/bin/cli.ts
+
+**目的**: CLI 実行時に正しいバイナリを使用
+
+**変更箇所**:
+
+| 行番号 | 変更前                          | 変更後                                      |
+|--------|--------------------------------|---------------------------------------------|
+| 112    | `npxCmd, ['prisma', ...]`      | node_modules/.bin/prisma を直接実行         |
+| 146    | `npxCmd, ['prisma', ...]`      | node_modules/.bin/prisma を直接実行         |
+| 258    | `npxCmd, ['pm2', ...]`         | node_modules/.bin/pm2 を直接実行            |
+| 280    | `npxCmd, ['pm2', ...]`         | node_modules/.bin/pm2 を直接実行            |
+| 301    | `npxCmd, ['pm2', ...]`         | node_modules/.bin/pm2 を直接実行            |
+| 319    | `npxCmd, ['pm2', ...]`         | node_modules/.bin/pm2 を直接実行            |
+| 331    | `npxCmd, ['pm2', ...]`         | node_modules/.bin/pm2 を直接実行            |
+
+**実装方法**:
+```typescript
+// ローカルバイナリのパスを解決
+const binDir = path.join(projectRoot, 'node_modules', '.bin');
+const prismaCmd = path.join(binDir, process.platform === 'win32' ? 'prisma.cmd' : 'prisma');
+const pm2Cmd = path.join(binDir, process.platform === 'win32' ? 'pm2.cmd' : 'pm2');
+```
+
+## 技術的決定事項
+
+### 決定1: node_modules/.bin の直接参照
+
+**検討した選択肢**:
+1. `node_modules/.bin/xxx` を直接参照
+   - メリット: 確実にローカルバージョンを使用
+   - デメリット: パスが長くなる
+2. `npx --no-install xxx`
+   - メリット: npx のキャッシュ機能を活用
+   - デメリット: 環境によっては動作が不安定
+
+**決定**: `node_modules/.bin` の直接参照
+
+**根拠**:
+- 確実性を優先
+- プラットフォーム対応（Windows では .cmd ファイル）も容易
+
+## ファイル変更一覧
+
+| ファイル            | 変更内容                                    |
+|---------------------|---------------------------------------------|
+| `package.json`      | prepare スクリプトで npx を削除             |
+| `src/bin/cli.ts`    | npx を node_modules/.bin に置換             |
+
+## テスト戦略
+
+### E2Eテスト
+
+既存の `e2e/npx-cli.spec.ts` で検証:
+- tarball からインストール後、CLI が正常動作すること
+- Prisma エラーが発生しないこと

--- a/docs/sdd-npx-prisma-fix/requirements.md
+++ b/docs/sdd-npx-prisma-fix/requirements.md
@@ -1,0 +1,45 @@
+# 要件定義: npx 実行時の依存バージョン不整合修正
+
+## 概要
+
+`npx github:windschord/claude-work` 実行時に、ローカルにインストールされた依存関係のバージョンではなく、グローバルまたは最新バージョンが使用される問題を修正する。
+
+## 背景
+
+現状の問題:
+1. `prepare` スクリプトで `npx prisma generate` を使用
+2. CLI コード内で `npx prisma` や `npx pm2` を使用
+3. これらは node_modules 内のバージョンではなく、グローバル/最新バージョンを使用する可能性がある
+4. Prisma 7.x には破壊的変更があり、5.x で動作するコードが動かない
+
+## ユーザーストーリー
+
+### ストーリー1: npx での正常起動
+
+**私は** ユーザーとして
+**〜したい** `npx github:windschord/claude-work start` で正常に起動したい
+**なぜなら** README に記載されている方法で使いたいから
+
+#### 受入基準（EARS記法）
+
+- **REQ-001**: `npx github:windschord/claude-work` を実行した時、システムは package.json で指定された Prisma バージョンを使用しなければならない
+- **REQ-002**: CLI がセットアップを実行する時、システムは node_modules 内の prisma コマンドを使用しなければならない
+- **REQ-003**: CLI が pm2 を実行する時、システムは node_modules 内の pm2 コマンドを使用しなければならない
+
+## 非機能要件
+
+### 互換性要件
+
+- **NFR-001**: 修正は既存の開発ワークフロー（`pnpm install`, `pnpm run dev`）に影響を与えてはならない
+- **NFR-002**: 修正は CI/CD 環境でも正常に動作しなければならない
+
+## 依存関係
+
+- Node.js 20以上
+- Prisma 5.22.0
+- pm2（dependencies に含まれる）
+
+## スコープ外
+
+- Prisma 7.x へのアップグレード
+- pm2 以外のプロセスマネージャー対応

--- a/docs/sdd-npx-prisma-fix/tasks.md
+++ b/docs/sdd-npx-prisma-fix/tasks.md
@@ -1,0 +1,147 @@
+# タスク: npx 実行時の依存バージョン不整合修正
+
+> このドキュメントはAIエージェント（Claude Code等）が実装を行うことを前提としています。
+
+## 実装計画
+
+### フェーズ1: package.json 修正
+
+#### タスク1.1: prepare スクリプトの修正
+
+**説明**:
+- 対象ファイル: `package.json`
+- 変更内容: `npx prisma generate` → `prisma generate`
+
+**技術的文脈**:
+- npm scripts 内では `node_modules/.bin` が PATH に自動追加される
+- `prisma` と書くだけでローカルの prisma が使用される
+
+**受入基準**:
+- [x] prepare スクリプトが `prisma generate` を使用している
+- [x] `npm install` 実行時に Prisma 5.x が使用される
+
+**依存関係**: なし
+**ステータス**: `DONE`
+
+---
+
+### フェーズ2: CLI コード修正
+
+#### タスク2.1: ローカルバイナリパス解決の追加
+
+**説明**:
+- 対象ファイル: `src/bin/cli.ts`
+- 変更内容: `prismaCmd` と `pm2Cmd` の定義を追加
+
+**技術的文脈**:
+```typescript
+const binDir = path.join(projectRoot, 'node_modules', '.bin');
+const prismaCmd = path.join(binDir, process.platform === 'win32' ? 'prisma.cmd' : 'prisma');
+const pm2Cmd = path.join(binDir, process.platform === 'win32' ? 'pm2.cmd' : 'pm2');
+```
+
+**受入基準**:
+- [x] `prismaCmd` 変数が定義されている
+- [x] `pm2Cmd` 変数が定義されている
+- [x] Windows 対応（.cmd 拡張子）が考慮されている
+
+**依存関係**: なし
+**ステータス**: `DONE`
+
+---
+
+#### タスク2.2: generatePrismaClient 関数の修正
+
+**説明**:
+- 対象ファイル: `src/bin/cli.ts`
+- 対象関数: `generatePrismaClient()` (112行目付近)
+- 変更内容: `spawnSync(npxCmd, ['prisma', 'generate'], ...)` → `spawnSync(prismaCmd, ['generate'], ...)`
+
+**受入基準**:
+- [x] `generatePrismaClient()` が `prismaCmd` を使用している
+- [x] 関数が正常に動作する
+
+**依存関係**: タスク2.1
+**ステータス**: `DONE`
+
+---
+
+#### タスク2.3: setupDatabase 関数の修正
+
+**説明**:
+- 対象ファイル: `src/bin/cli.ts`
+- 対象関数: `setupDatabase()` (146行目付近)
+- 変更内容: `spawnSync(npxCmd, ['prisma', 'db', 'push', ...], ...)` → `spawnSync(prismaCmd, ['db', 'push', ...], ...)`
+
+**受入基準**:
+- [x] `setupDatabase()` が `prismaCmd` を使用している
+- [x] 関数が正常に動作する
+
+**依存関係**: タスク2.1
+**ステータス**: `DONE`
+
+---
+
+#### タスク2.4: pm2 関連関数の修正
+
+**説明**:
+- 対象ファイル: `src/bin/cli.ts`
+- 対象関数:
+  - `startDaemon()` (258行目)
+  - `stopDaemon()` (280行目)
+  - `restartDaemon()` (301行目)
+  - `showStatus()` (319行目)
+  - `showLogs()` (331行目)
+- 変更内容: `npxCmd, ['pm2', ...]` → `pm2Cmd, [...]`
+
+**受入基準**:
+- [x] 全ての pm2 呼び出しが `pm2Cmd` を使用している
+- [x] 各関数が正常に動作する
+
+**依存関係**: タスク2.1
+**ステータス**: `DONE`
+
+---
+
+### フェーズ3: テストと検証
+
+#### タスク3.1: E2Eテストの実行
+
+**説明**:
+- `e2e/npx-cli.spec.ts` を実行して動作確認
+- 必要に応じてテストを追加
+
+**受入基準**:
+- [x] E2E テストで Prisma 5.22.0 が正しく使用される（`npm pack` 時の data/repos 問題は別課題）
+- [x] Prisma バージョンエラーが発生しない
+
+**依存関係**: タスク2.4
+**ステータス**: `DONE`
+
+**備考**: E2E テストは `data/repos` 内の別プロジェクトが含まれてしまうことで Next.js ビルドが失敗するが、Prisma は正しく 5.22.0 が使用されている。
+
+---
+
+#### タスク3.2: 手動検証
+
+**説明**:
+- 実際に `npx github:windschord/claude-work` を実行して検証
+
+**受入基準**:
+- [x] `help` コマンドが動作する
+- [x] `status` コマンドが動作する
+- [ ] `start` コマンドが Prisma エラーなく実行される（PR マージ後に検証）
+- [ ] `stop` コマンドが動作する（PR マージ後に検証）
+
+**依存関係**: タスク3.1
+**ステータス**: `IN_PROGRESS`
+
+**備考**: ローカルでの CLI 実行は確認済み。実際の `npx github:...` 実行は PR マージ後に検証。
+
+---
+
+## タスクステータスの凡例
+
+- `TODO` - 未着手
+- `IN_PROGRESS` - 作業中
+- `DONE` - 完了

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "prepare": "npx prisma generate && DATABASE_URL=file:./data/build.db npm run build",
+    "prepare": "prisma generate && DATABASE_URL=file:./data/build.db npm run build",
     "dev": "ts-node -r tsconfig-paths/register --project tsconfig.server.json server.ts",
     "dev:pm2": "pm2 start ecosystem.config.js --only claude-work-dev",
     "dev:stop": "pm2 stop claude-work-dev",


### PR DESCRIPTION
## Summary

- `npx github:windschord/claude-work` 実行時に、グローバルの Prisma 7.x が使用される問題を修正
- `npx prisma` / `npx pm2` を `node_modules/.bin/` への直接参照に置換
- Windows 対応（`.cmd` 拡張子）も考慮

## Background

`npx prisma` コマンドはグローバルにインストールされた Prisma を使用する可能性があり、Prisma 7.x が利用可能な環境では破壊的変更により以下のエラーが発生していました：

```
The datasource property 'url' is no longer supported in schema files.
```

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `package.json` | `npx prisma generate` → `prisma generate` |
| `src/bin/cli.ts` | `npxCmd` を `prismaCmd` / `pm2Cmd` に置換 |

## Test plan

- [x] CLI ユニットテスト通過
- [x] E2E テストで Prisma 5.22.0 が正しく使用されることを確認
- [x] `node dist/src/bin/cli.js help` 動作確認
- [x] `node dist/src/bin/cli.js status` 動作確認
- [ ] PR マージ後に `npx github:windschord/claude-work start` で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Prisma バージョン一貫性の修正に関する設計・要件・実装タスクのドキュメントを追加しました。

* **バグ修正**
  * npx 経由でグローバル Prisma が使用される問題を修正し、ローカルインストールされた Prisma バージョンを確実に使用するようになりました。
  * 準備スクリプトとバイナリ解決ロジックを更新し、ロックされたバージョンの Prisma が正しく実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->