### PR TITLE
fix: npx に --yes フラグを追加

### DIFF
--- a/docs/sdd-systemd-setup/design.md
+++ b/docs/sdd-systemd-setup/design.md
@@ -22,7 +22,7 @@
 │  │    ├─ User=claude-work                              │    │
 │  │    ├─ WorkingDirectory=/opt/claude-work             │    │
 │  │    ├─ EnvironmentFile=/etc/claude-work/env          │    │
-│  │    └─ ExecStart=/usr/bin/npx github:windschord/claude-work │
+│  │    └─ ExecStart=/usr/bin/npx --yes github:windschord/claude-work@latest │
 │  │                                                      │    │
 │  └─────────────────────────────────────────────────────┘    │
 │                          │                                   │
@@ -69,7 +69,7 @@ EnvironmentFile=/etc/claude-work/env
 #   - 2回目以降はキャッシュを利用（オフライン起動可能）
 # 初回実行時に自動セットアップ（Prisma、DB、ビルド）を実行
 Environment=HOME=/opt/claude-work
-ExecStart=/usr/bin/npx github:windschord/claude-work
+ExecStart=/usr/bin/npx --yes github:windschord/claude-work@latest
 # 初回起動時のビルドに時間がかかるためタイムアウトを延長
 TimeoutStartSec=300
 Restart=on-failure

--- a/systemd/claude-work.service
+++ b/systemd/claude-work.service
@@ -21,7 +21,7 @@ EnvironmentFile=/etc/claude-work/env
 #   2. ProtectHome=read-only との競合を回避
 #   3. 自己完結型インストールを維持
 Environment=HOME=/opt/claude-work
-ExecStart=/usr/bin/npx github:windschord/claude-work
+ExecStart=/usr/bin/npx --yes github:windschord/claude-work@latest
 # 初回起動時のビルドに時間がかかるためタイムアウトを延長
 TimeoutStartSec=300
 Restart=on-failure


### PR DESCRIPTION
## Summary
npx がパッケージインストールの確認ダイアログを表示するため、非対話的な systemd 環境では失敗していた問題を修正。

## Problem
```
Need to install the following packages:
github:windschord/claude-work
Ok to proceed? (y)
```
systemd サービスでは対話的な応答ができないため、exit code 128 で失敗。

## Solution
`npx --yes github:windschord/claude-work@latest`

- `--yes`: 自動的に確認に応答
- `@latest`: 常に最新版を取得

## Test plan
- [ ] systemd サービスが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * systemd サービス設定ドキュメントを更新しました。

* **保守**
  * サービス実行時に自動確認フラグを追加し、最新バージョンを明示的に指定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->