### PR TITLE
fix: detectClaudePathでコマンド名をwhichで解決

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,10 +32,9 @@ ALLOWED_PROJECT_DIRS=
 
 # Claude Code Path (optional)
 # Specify the path to the Claude Code executable
-# Default: claude (uses system PATH)
+# Default: auto-detect from system PATH using 'which claude'
 # Example: /Users/yourusername/.claude/local/claude
-# Or use 'claude' to use the command from your PATH
-CLAUDE_CODE_PATH=claude
+# CLAUDE_CODE_PATH=/usr/local/bin/claude
 
 # Anthropic API Key (optional, required for Docker mode on macOS)
 # On macOS, Claude Code stores credentials in Keychain which is not accessible from Docker containers.

--- a/src/lib/__tests__/env-validation.test.ts
+++ b/src/lib/__tests__/env-validation.test.ts
@@ -145,7 +145,7 @@ describe('detectClaudePath', () => {
 
     expect(() => {
       detectClaudePath();
-    }).toThrow(/CLAUDE_CODE_PATH.*claude.*not found/);
+    }).toThrow('CLAUDE_CODE_PATH is set but the path does not exist: claude');
   });
 
   it('CLAUDE_CODE_PATHが未設定で、whichコマンドでclaudeが見つかる場合、そのパスを返す', () => {


### PR DESCRIPTION
## Summary

- `detectClaudePath()`で`CLAUDE_CODE_PATH`がコマンド名(非絶対パス)の場合、`existsSync`だけでなく`which`で解決を試みるよう修正
- `.env.example`の`CLAUDE_CODE_PATH=claude`をコメントアウトし、デフォルトで自動検出が動くようにした
- systemd環境で`.env`からコピーされた`CLAUDE_CODE_PATH=claude`が`existsSync('claude')`で失敗していた問題を解消

## Test plan

- [x] env-validation.test.ts 14テスト全通過
- [x] コマンド名でwhichで見つかるケース -> 解決されたパスを返す
- [x] コマンド名でwhichでも見つからないケース -> エラーをスロー
- [ ] systemdサービスが正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Claudeコマンドのパス解決機能を改善しました。環境変数の設定時にシステムPATHから自動的にコマンドを検出するようになり、完全なパスではなくコマンド名のみでの指定に対応しています。

* **テスト**
  * パス解決ロジックの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->