### PR TITLE
fix: Dockerfileを必要最低限のツール構成に整理

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,24 +7,25 @@ FROM node:20-slim
 LABEL maintainer="Claude Work"
 LABEL description="Sandboxed environment for running Claude Code"
 
-# 必要最低限のツールをインストール (git, gh, curl, wget, bash)
+# 必要最低限のツールをインストール (git, gh, openssh-client, curl, wget, bash)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
+        openssh-client \
         curl \
         wget \
         bash \
         ca-certificates \
-        gnupg \
     && mkdir -p /etc/apt/keyrings \
     && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh \
-    && apt-get purge -y gnupg \
     && apt-get autoremove -y \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Claude Codeをインストール
@@ -32,10 +33,16 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # nodeユーザーを使用（node:20-slimに既存のUID 1000）
 # /home/claude → /home/node のシンボリックリンク
-RUN ln -s /home/node /home/claude
+RUN [ -e /home/claude ] || ln -s /home/node /home/claude
+
+# SSHディレクトリの準備（マウント用）
+RUN mkdir -p /home/node/.ssh \
+    && chmod 700 /home/node/.ssh \
+    && chown node:node /home/node/.ssh
 
 # Claude設定ディレクトリの準備（マウント用）
 RUN mkdir -p /home/node/.claude /home/node/.config/claude \
+    && chmod 700 /home/node/.claude /home/node/.config/claude \
     && chown -R node:node /home/node/.claude /home/node/.config
 
 # ワークスペースディレクトリの準備


### PR DESCRIPTION
gh (GitHub CLI)とwgetを追加し、不要なopenssh-clientとSSH設定を削除。 gnupgはgh APTキー登録後にpurgeしてイメージサイズを削減。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コンテナ内の開発ツールを拡充しました（git/curl/wget/GitHub CLI 等を追加）。
  * 設定ディレクトリやワークスペースの作成・所有権設定を簡素化しました。
  * 非root実行は維持しつつ、イメージのデフォルト起動挙動に依存するように起動設定・ヘルスチェック・一部環境変数を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->