### PR TITLE
docs: systemd設定でHOME=/opt/claude-workを前提にPATH/SSH問題を解消

### DIFF
--- a/docs/SYSTEMD_SETUP.md
+++ b/docs/SYSTEMD_SETUP.md
@@ -219,7 +219,7 @@ HOST=0.0.0.0
 > **DATA_DIR について**: `npx github:windschord/claude-work` で起動する場合、カレントディレクトリは npx キャッシュ内のパッケージディレクトリになります。`DATA_DIR` を設定しない場合、`repos/`（clone したリポジトリ）や `environments/`（Docker 環境の認証情報）がキャッシュ内に作成され、`npx` キャッシュの再構築時にデータが消失します。`DATABASE_URL` と同じディレクトリ（`/opt/claude-work/data`）を指定することを推奨します。
 
 > **注意**: `HOST=0.0.0.0` を設定すると、すべてのネットワークインターフェースでリッスンします。セキュリティのため、ファイアウォールや認証（`CLAUDE_WORK_TOKEN`）の設定を推奨します。
-> **CLAUDE_CODE_PATH について**: systemd サービスの PATH に `/opt/claude-work/.local/bin` が含まれているため、通常は設定不要です。別の場所にインストールした場合のみ絶対パスを指定してください。
+> **CLAUDE_CODE_PATH について**: systemd サービスの PATH に `/opt/claude-work/.local/bin` が含まれているため、通常は設定不要です。別の場所にインストールした場合は、絶対パスまたは PATH 上で解決可能なコマンド名を指定できます。
 
 ---
 
@@ -245,7 +245,7 @@ sudo systemctl daemon-reload
 | 設定 | 値 | 説明 |
 | --- | --- | --- |
 | `HOME` | `/opt/claude-work` | ホームディレクトリ (`~/.npm`, `~/.ssh` 等の基準) |
-| `PATH` | `/opt/claude-work/.local/bin:...` | Claude CLI を含む PATH |
+| `PATH` | `...:/opt/claude-work/.local/bin` | システムパスの後に Claude CLI パスを追加 |
 | `ProtectHome` | `read-only` | `/home/*` への書き込みを制限 |
 | `ReadWritePaths` | `/opt/claude-work` | アプリケーションディレクトリへの書き込みを許可 |
 
@@ -398,7 +398,7 @@ systemd サービスはセキュリティ強化のため `ProtectHome=read-only`
 
 ```bash
 # claude-work ユーザーとして手動実行（デバッグ用）
-sudo -u claude-work bash -c 'set -a && source /etc/claude-work/env && set +a && cd /opt/claude-work && HOME=/opt/claude-work PATH=/opt/claude-work/.local/bin:$PATH npx --yes github:windschord/claude-work'
+sudo -u claude-work bash -c 'set -a && source /etc/claude-work/env && set +a && cd /opt/claude-work && HOME=/opt/claude-work PATH=$PATH:/opt/claude-work/.local/bin npx --yes github:windschord/claude-work'
 ```
 
 ---

--- a/systemd/claude-work.env.example
+++ b/systemd/claude-work.env.example
@@ -28,7 +28,7 @@ NODE_ENV=production
 # Claude Code CLI パス（オプション）
 # systemd サービスの PATH に /opt/claude-work/.local/bin が含まれているため、
 # claude-work ユーザーにインストールした CLI は自動検出されます。
-# 別の場所にインストールした場合のみ絶対パスを指定してください。
+# 別の場所にインストールした場合は、絶対パスまたは PATH 上のコマンド名を指定してください。
 # CLAUDE_CODE_PATH=/usr/local/bin/claude
 
 # 許可するプロジェクトディレクトリ（オプション）

--- a/systemd/claude-work.service
+++ b/systemd/claude-work.service
@@ -24,7 +24,8 @@ EnvironmentFile=/etc/claude-work/env
 Environment=HOME=/opt/claude-work
 # PATH に ~/.local/bin を含めることで、claude-work ユーザーにインストールした
 # Claude Code CLI を自動検出可能にする（CLAUDE_CODE_PATH の明示指定が不要になる）
-Environment=PATH=/opt/claude-work/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# セキュリティ上の理由から、ユーザー書き込み可能な ~/.local/bin はシステムパスの後に配置する
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/claude-work/.local/bin
 ExecStart=/usr/bin/npx --yes github:windschord/claude-work
 # 初回起動時のビルドに時間がかかるためタイムアウトを延長
 TimeoutStartSec=300


### PR DESCRIPTION
## Summary

- systemd サービスファイルに `PATH` 環境変数を追加し、`/opt/claude-work/.local/bin` を含めることで Claude Code CLI が自動検出されるようにした
- `docs/SYSTEMD_SETUP.md` を改訂し、`HOME=/opt/claude-work` を前提とした一貫性のあるセットアップ手順に整理した
- Claude Code CLI のインストール手順セクションを新規追加した

## Changes

### `systemd/claude-work.service`
- `Environment=PATH=...` を追加（`/opt/claude-work/.local/bin` をシステムパスの末尾に配置）
- HOME 設定のコメントを更新（npm, SSH, Claude CLI が HOME 配下に統一される旨を説明）

### `docs/SYSTEMD_SETUP.md`
- 「Claude Code CLI のインストール」セクションを新規追加
- セクション順序を論理的に再配置（ユーザー作成 -> ディレクトリ準備 -> CLI インストール -> SSH 鍵）
- SSH 鍵の説明を簡素化（HOME=/opt/claude-work により `~/.ssh` が自然に解決される）
- ディレクトリ構成図を追加
- `CLAUDE_CODE_PATH` を真のオプションに変更（PATH が解決するため通常不要）
- サービスの主要設定一覧テーブルを追加

### `systemd/claude-work.env.example`
- `CLAUDE_CODE_PATH` のコメントを更新（PATH に含まれるため通常不要である旨を記載）

## Test plan

- [ ] `systemd/claude-work.service` の構文が正しいことを確認
- [ ] ドキュメントの手順に従って新規環境でセットアップが完了できることを確認
- [ ] `claude-work` ユーザーで `claude --version` が PATH 経由で実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)