### PR TITLE
fix: ヘッダーアイコンを実行環境に合ったServerアイコンに変更

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -79,14 +79,14 @@ export function Header() {
         </button>
       </div>
 
-      {/* 右側: 設定メニュー + 通知設定 + テーマ切り替え */}
+      {/* 右側: 実行環境メニュー + 通知設定 + テーマ切り替え */}
       <div className="flex items-center gap-2">
-        {/* 設定メニュー */}
+        {/* 実行環境メニュー */}
         <div className="relative" ref={settingsRef}>
           <button
             onClick={handleSettingsClick}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-            aria-label="設定"
+            aria-label="実行環境"
             aria-expanded={isSettingsOpen}
             aria-haspopup="true"
           >


### PR DESCRIPTION
## Summary
- ヘッダー右上の歯車アイコン（Settings）をServerアイコンに変更
- ドロップダウンの内容が「実行環境」のみのため、機能に合ったアイコンに統一
- 不要になったSettingsのimportを削除

## Test plan
- [ ] ヘッダー右上のアイコンがサーバーアイコンに変わっていることを確認
- [ ] アイコンクリックでドロップダウンが正常に表示されることを確認
- [ ] ドロップダウンから実行環境ページへ遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **UI/デザイン**
  * ヘッダー右側の「設定」メニューを「実行環境」メニューに置き換え、アイコンを Settings から Server に変更しました。
  * メニューの表示ラベルと aria-label を「設定」→「実行環境」に更新しました。
  * ドロップダウン内のラベルとアイコン表示も実行環境に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->