### PR TITLE
fix: npxキャッシュクリアをsystemdサービス起動前に自動実行

### DIFF
--- a/systemd/claude-work.service
+++ b/systemd/claude-work.service
@@ -26,7 +26,10 @@ Environment=HOME=/opt/claude-work
 # Claude Code CLI を自動検出可能にする（CLAUDE_CODE_PATH の明示指定が不要になる）
 # セキュリティ上の理由から、ユーザー書き込み可能な ~/.local/bin はシステムパスの後に配置する
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/claude-work/.local/bin
-ExecStart=/usr/bin/npx --yes github:windschord/claude-work
+# npx キャッシュをクリア（バージョン更新時のENOTEMPTYエラー回避）
+ExecStartPre=/bin/rm -rf /opt/claude-work/.npm/_npx
+# npm_config_loglevel=info でnpxのダウンロード・ビルド進捗をログに出力
+ExecStart=/usr/bin/env npm_config_loglevel=info /usr/bin/npx --yes github:windschord/claude-work
 # 初回起動時のビルドに時間がかかるためタイムアウトを延長
 TimeoutStartSec=300
 Restart=on-failure


### PR DESCRIPTION
## Summary
- systemdサービス起動前にnpxキャッシュを自動クリアするExecStartPreを追加
- バージョン更新時のENOTEMPTYエラーを防止

## 問題
バージョン更新後にsystemdサービスを再起動すると、npxキャッシュディレクトリのリネームでENOTEMPTYエラーが発生していた。

## 解決策
`ExecStartPre=/bin/rm -rf /opt/claude-work/.npm/_npx` を追加し、毎回クリーンな状態で起動するようにした。

## Test plan
- [ ] systemdサービスが正常に起動する
- [ ] バージョン更新後も正常に再起動できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * サービスの起動時の信頼性が向上しました。
  * 起動時のキャッシュクリーンアップと詳細なログ出力により、サービス動作の診断と監視がしやすくなりました。
  * 再起動時の待機時間設定を追加し、サービスの安定性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->