### PR TITLE
fix: systemd環境でdrizzle-kit pushが設定ファイルを見つけられないバグを修正

### DIFF
--- a/src/bin/__tests__/cli-utils.test.ts
+++ b/src/bin/__tests__/cli-utils.test.ts
@@ -161,16 +161,21 @@ describe('cli-utils', () => {
       mockSpawnSync.mockReset();
     });
 
-    it('drizzle-kit pushを実行する', () => {
+    it('drizzle-kit pushをパッケージルートのcwdと--configフラグで実行する', () => {
       mockSpawnSync.mockReturnValue({ status: 0 });
 
       syncSchema('file:test.db');
 
       expect(mockSpawnSync).toHaveBeenCalledWith(
         'npx',
-        ['drizzle-kit', 'push'],
+        expect.arrayContaining([
+          'drizzle-kit',
+          'push',
+          expect.stringMatching(/--config=.*drizzle\.config\.ts$/),
+        ]),
         expect.objectContaining({
           stdio: 'inherit',
+          cwd: expect.stringContaining('claude-work'),
           env: expect.objectContaining({ DATABASE_URL: 'file:test.db' }),
         })
       );


### PR DESCRIPTION
## 問題

Systemdでデプロイ後、`drizzle-kit push` が設定ファイルを見つけられずエラーが発生。

```
No config path provided, using default 'drizzle.config.json'
/opt/claude-work/drizzle.config.json file does not exist
Failed to sync database schema: Error: drizzle-kit push failed with exit code 1
```

## 根本原因

`syncSchema()` が `cwd: process.cwd()` を使用していたため、systemd実行時の
`process.cwd()` = `/opt/claude-work/` で `drizzle-kit push` が実行されていた。
設定ファイル (`drizzle.config.ts`) はnpmパッケージ内に存在するが、
systemdのCWDには存在しないためエラーになっていた。

## 修正内容

- `findPackageRoot()` 関数を追加。`__dirname` から `package.json` を探索し
  パッケージルートを特定（TypeScriptソース `src/bin/` でもコンパイル済み `dist/src/bin/` でも正しく動作）
- `spawnSync` の `cwd` を `packageRoot` に変更
- `--config` フラグで `drizzle.config.ts` の絶対パスを明示的に指定

## Test plan

- [ ] `npm test` が全てパスすること（145ファイル / 1710テスト）
- [ ] CI が全てグリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ドリズルキット同期テストの検証基準を強化しました

* **改善**
  * スキーマ同期時の設定解決とプロセス実行コンテキストを改善し、より堅牢な実行環境を実現しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->