### PR TITLE
fix: .npmignoreからdrizzle.config.tsを削除してnpmパッケージに含める

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -47,9 +47,8 @@ src/generated/
 *.tsbuildinfo
 .next/cache/
 
-# Drizzle開発ツール設定
+# Drizzle開発ツール設定（drizzle.config.tsはdrizzle-kit push実行時に必要なため除外しない）
 drizzle/
-drizzle.config.ts
 
 # PM2ログ
 logs/


### PR DESCRIPTION
## 問題

PR #110 の修正後も以下のエラーが継続していた。

```
/opt/claude-work/.npm/_npx/de0642b7c9adfaa3/node_modules/claude-work/drizzle.config.ts file does not exist
Failed to sync database schema: Error: drizzle-kit push failed with exit code 1
```

## 根本原因

`.npmignore` の52行目に `drizzle.config.ts` が明示的に除外されていた。

```
# Drizzle開発ツール設定
drizzle/
drizzle.config.ts   ← npmパッケージから除外されていた
```

PR #110 で `cwd` をパッケージルートに修正したことで、正しいパスを参照するようになったが、ファイル自体が存在しないためエラーが続いていた。

## 修正内容

`drizzle.config.ts` はsystemd実行時の `drizzle-kit push` に必要なため、`.npmignore` から除外ルールを削除。

`npm pack --dry-run` で以下のファイルがパッケージに含まれることを確認済み:
- `drizzle.config.ts` (576B)
- `src/db/schema.ts` (8.5kB)

## 関連

- PR #109: スキーマ同期の自動化
- PR #110: `syncSchema` のcwd修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージ設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->