### PR TITLE
fix: syncSchemaのcwdをパッケージルートに設定しdrizzle-ormを解決できるよう修正

### DIFF
--- a/src/bin/__tests__/cli-utils.test.ts
+++ b/src/bin/__tests__/cli-utils.test.ts
@@ -176,6 +176,8 @@ describe('cli-utils', () => {
         ]),
         expect.objectContaining({
           stdio: 'inherit',
+          // drizzle-orm解決のためにパッケージルートをcwdに設定していること
+          cwd: expect.stringContaining('claude-work'),
           env: expect.objectContaining({ DATABASE_URL: 'file:test.db' }),
         })
       );

--- a/src/bin/cli-utils.ts
+++ b/src/bin/cli-utils.ts
@@ -90,8 +90,11 @@ export function syncSchema(databaseUrl: string): void {
       })
     );
 
+    // cwd をパッケージルートに設定することで、drizzle-kit が drizzle-orm を
+    // パッケージの node_modules から解決できるようにする
     const result = spawnSync('npx', ['drizzle-kit', 'push', `--config=${tmpConfig}`], {
       stdio: 'inherit',
+      cwd: packageRoot,
       env: { ...process.env, DATABASE_URL: databaseUrl },
     });
 


### PR DESCRIPTION
## 問題

PR #113 の修正後も以下のエラーが継続。

```
Reading config file '/tmp/drizzle-config-885738.json'
Error please install required packages: 'drizzle-orm'
```

## 根本原因

PR #113 で一時 JSON 設定ファイルに切り替えた際、`spawnSync` から `cwd` を省略した。
その結果、`drizzle-kit push` のサブプロセスが systemd の作業ディレクトリ
`/opt/claude-work/` を起点に `drizzle-orm` を探すが、そこには存在しない。

`drizzle-orm` はパッケージの `node_modules` に存在するため、
`cwd: packageRoot` を設定する必要がある。

## 修正内容

`spawnSync` に `cwd: packageRoot` を追加し、`drizzle-kit push` が
パッケージの `node_modules/drizzle-orm` を解決できるようにした。

## 関連

- PR #109 〜 #113: systemd 起動時スキーマ同期エラーの段階的修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * CLIツールのワーキングディレクトリを修正し、パッケージの正しい解決を保証しました。これにより、drizzle-kit pushコマンドがより確実に動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->