### PR TITLE
Optimize E2E tests with pre-built CLI package caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,17 +112,23 @@ jobs:
       with:
         skip-db-setup: 'true'
 
+    - name: Get Node.js version for cache key
+      id: node-version
+      run: echo "version=$(node --version)" >> $GITHUB_OUTPUT
+
     - name: Cache CLI E2E package
       uses: actions/cache@v4
       id: cli-package-cache
       with:
         path: /tmp/cli-e2e-package
-        key: cli-e2e-pkg-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'src/**', 'server.ts', 'tsconfig*.json', 'next.config.js', 'tailwind.config.*', 'postcss.config.*', '.npmignore') }}
+        # src/** を含めることでビルド成果物に影響する全ソースの変更を検出する。
+        # テストファイルの変更でもキャッシュが無効化されるが、ビルドの正確性を優先する。
+        key: cli-e2e-pkg-${{ runner.os }}-node${{ steps.node-version.outputs.version }}-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'src/**', 'server.ts', 'tsconfig*.json', 'next.config.js', 'tailwind.config.*', 'postcss.config.*', '.npmignore') }}
 
     - name: Build CLI E2E package
       if: steps.cli-package-cache.outputs.cache-hit != 'true'
       run: |
-        set -e
+        set -eo pipefail
         echo "=== npm pack ==="
         TARBALL_NAME=$(npm pack --ignore-scripts | tail -1)
         echo "Created tarball: $TARBALL_NAME"
@@ -140,8 +146,24 @@ jobs:
 
     - name: Verify CLI package
       run: |
-        test -f /tmp/cli-e2e-package/package/dist/src/bin/cli.js
-        test -d /tmp/cli-e2e-package/package/.next
+        pkg=/tmp/cli-e2e-package/package
+        ok=true
+        for f in dist/src/bin/cli.js package.json; do
+          if [ ! -f "$pkg/$f" ]; then
+            echo "::error::Missing required file: $pkg/$f"
+            ok=false
+          fi
+        done
+        if [ ! -d "$pkg/.next" ]; then
+          echo "::error::Missing required directory: $pkg/.next"
+          ok=false
+        fi
+        if [ "$ok" != "true" ]; then
+          echo "CLI package verification failed. Listing contents:"
+          ls -la "$pkg"
+          exit 1
+        fi
+        echo "CLI package verified successfully"
 
     - name: Run CLI E2E tests
       run: SKIP_WEBSERVER=true CLI_PACKAGE_DIR=/tmp/cli-e2e-package/package pnpm exec playwright test --project=cli

--- a/e2e/npx-cli.spec.ts
+++ b/e2e/npx-cli.spec.ts
@@ -36,6 +36,9 @@ test.describe.serial('npx CLI installation test', () => {
     // CI最適化: 事前ビルド済みパッケージディレクトリが指定されている場合はそれを使用
     const prebuiltDir = process.env.CLI_PACKAGE_DIR;
     if (prebuiltDir && fs.existsSync(prebuiltDir)) {
+      if (!fs.statSync(prebuiltDir).isDirectory()) {
+        throw new Error(`CLI_PACKAGE_DIR is not a directory: ${prebuiltDir}`);
+      }
       const requiredArtifacts = [
         path.join(prebuiltDir, 'dist', 'src', 'bin', 'cli.js'),
         path.join(prebuiltDir, '.next'),


### PR DESCRIPTION
## Summary
This PR optimizes the E2E test pipeline by introducing a caching mechanism for the pre-built CLI package, reducing build time and improving CI efficiency.

## Key Changes
- **Workflow optimization**: Reduced E2E test timeout from 15 to 10 minutes by separating CLI package building into a cached step
- **Package caching**: Added GitHub Actions cache for the built CLI package with a hash key based on relevant source files and configuration
- **Build step separation**: Extracted CLI package building (`npm pack` and `npm install`) into a dedicated step with its own 8-minute timeout
- **Package verification**: Added verification step to ensure the built package contains required files (`dist/src/bin/cli.js` and `.next` directory)
- **Test environment variable**: Modified E2E test to accept `CLI_PACKAGE_DIR` environment variable to use pre-built packages instead of building on-the-fly
- **Cleanup optimization**: Updated test suite to skip cleanup when using pre-built packages (managed by CI cache), reducing test teardown time

## Implementation Details
- The cache key includes `package.json`, `pnpm-lock.yaml`, source files under `src/bin/`, TypeScript configs, `next.config.js`, and `.npmignore` to ensure cache invalidation when relevant files change
- The pre-built package is stored in `/tmp/cli-e2e-package` and reused across test runs when cache hits occur
- Test timeout for CLI E2E tests reduced from 10 to 3 minutes since package building is now handled separately
- The test suite gracefully falls back to building its own package if the pre-built one is not available (for local development)

https://claude.ai/code/session_019S6iTUL9igPBNHikykFoUe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E テストのタイムアウトを 15 分から 10 分に短縮しました
  * CLI 実行フェーズの短いタイムアウト（約3分指定の短い実行）を導入しました
  * CLI ベースの E2E フローでビルド成果物の存在検証を追加しました
  * テスト環境設定を最適化し、不要な環境変数を削除しました
* **Chores**
  * CI での CLI パッケージのキャッシュ／再利用を追加し、事前ビルドの検出とクリーンアップ制御を導入しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->