### PR TITLE
fix: Dockerビルド失敗を修正（pnpm rebuildをネイティブモジュール限定に変更）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ COPY package.json pnpm-lock.yaml ./
 # --ignore-scripts でprepareスクリプト(npm run build)の実行を抑制（ソースファイル未コピーのため）
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 # ネイティブモジュール（better-sqlite3, node-pty）を明示的にビルド
-# --ignore-scriptsで抑制されたpostinstallを再実行する
-RUN pnpm rebuild
+# pnpm rebuild だけだとルートpackage.jsonのprepareスクリプトも実行されるため
+# パッケージ名を指定してネイティブモジュールのみビルドする
+RUN pnpm rebuild better-sqlite3 node-pty
 
 # =============================================================================
 # Stage 3: deps-all - 全依存関係（ビルド用）
@@ -36,7 +37,7 @@ COPY package.json pnpm-lock.yaml ./
 # --ignore-scripts でprepareスクリプト(npm run build)の実行を抑制（ソースファイル未コピーのため）
 RUN pnpm install --frozen-lockfile --ignore-scripts
 # ネイティブモジュール（better-sqlite3, node-pty）を明示的にビルド
-RUN pnpm rebuild
+RUN pnpm rebuild better-sqlite3 node-pty
 
 # =============================================================================
 # Stage 4: builder - アプリケーションビルド


### PR DESCRIPTION
## Summary

- `pnpm rebuild`（引数なし）がルートpackage.jsonの`prepare`スクリプト（`next build`）を実行してしまい、ソースファイルが存在しないdeps-prod/deps-allステージでビルドが失敗していた問題を修正
- `pnpm rebuild better-sqlite3 node-pty` に変更してネイティブモジュールのみビルドするよう限定

## Root Cause

`v0.1.0-rc.1`タグのreleaseワークフローで以下のエラーが発生:
```
ERROR: process "/bin/sh -c pnpm rebuild" did not complete successfully: exit code: 1
```

`pnpm rebuild`（引数なし）はルートpackage.jsonの`prepare`スクリプトも実行するため、ソースファイルがコピーされていないdepsステージで`next build`が失敗する。

## Fix

```dockerfile
# Before
RUN pnpm rebuild

# After  
RUN pnpm rebuild better-sqlite3 node-pty
```

## Test plan

- [ ] releaseワークフローが正常に完了すること
- [ ] GHCRにDockerイメージが公開されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ネイティブモジュールのビルドプロセスを最適化しました。ビルド効率が向上し、不要な再構築が削減されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->