### PR TITLE
fix: node-gypをグローバルインストールしてnode-ptyのLinuxビルドを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 # pnpmのバージョンを固定してビルドの再現性を確保
-RUN npm install -g pnpm@9.15.9
+# node-gypをグローバルインストール: node-ptyはLinux向けprebuiltがなくソースビルドが必要なため
+RUN npm install -g pnpm@9.15.9 node-gyp
 WORKDIR /app
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- `node-pty` はLinux向けのprebuiltバイナリを持たないため、Dockerビルド時にソースコンパイルが必要
- しかし `node-gyp` がPATHに含まれておらず `pnpm rebuild node-pty` が実行されても `node-gyp rebuild` が「command not found」で失敗していた
- `npm install -g pnpm@9.15.9 node-gyp` に変更してnode-gypをグローバルインストールすることで修正

## Root Cause

`v0.1.0-rc.2` のDockerイメージで `node-pty` のネイティブモジュール読み込みが失敗:

```
Error: Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-arm64
```

node-ptyのinstallスクリプト: `"install": "node scripts/prebuild.js || node-gyp rebuild"`
- `prebuild.js`: linuxのprebuiltなし → exit 1
- `node-gyp rebuild`: node-gypがPATHにない → command not found → exit 127
- pnpmはエラーを無視して続行 → `build/Release/pty.node` が生成されない

better-sqlite3は linux-arm64 向けprebuiltをダウンロードするため影響なし。

## Test plan

- [ ] DockerビルドがCIで成功すること
- [ ] コンテナ起動時に `pty.node` の読み込みエラーが発生しないこと
- [ ] アプリがブラウザからアクセスできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア（その他）**
  * ビルド環境の依存関係をアップデートしました。pnpm@9.15.9とnode-gypをグローバルにインストールするよう変更し、ネイティブモジュールのビルドサポートを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->