### PR TITLE
fix: node-ptyをソースから直接ビルドするよう変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 # ネイティブモジュール（better-sqlite3, node-pty）を明示的にビルド
 # pnpm rebuild だけだとルートpackage.jsonのprepareスクリプトも実行されるため
 # パッケージ名を指定してネイティブモジュールのみビルドする
-RUN pnpm rebuild better-sqlite3 node-pty
+RUN pnpm rebuild better-sqlite3
+# node-ptyはLinux向けprebuiltがなくソースビルドが必要だが、pnpm rebuildはinstallスクリプトを
+# 実行しないため、node-ptyディレクトリで直接 npm run install（= node-gyp rebuild）を実行する
+RUN cd node_modules/.pnpm/node-pty@*/node_modules/node-pty && npm run install
 
 # =============================================================================
 # Stage 3: deps-all - 全依存関係（ビルド用）
@@ -38,7 +41,8 @@ COPY package.json pnpm-lock.yaml ./
 # --ignore-scripts でprepareスクリプト(npm run build)の実行を抑制（ソースファイル未コピーのため）
 RUN pnpm install --frozen-lockfile --ignore-scripts
 # ネイティブモジュール（better-sqlite3, node-pty）を明示的にビルド
-RUN pnpm rebuild better-sqlite3 node-pty
+RUN pnpm rebuild better-sqlite3
+RUN cd node_modules/.pnpm/node-pty@*/node_modules/node-pty && npm run install
 
 # =============================================================================
 # Stage 4: builder - アプリケーションビルド


### PR DESCRIPTION
## Summary

- `pnpm rebuild node-pty` が node-pty のinstallスクリプト（`node-gyp rebuild`）を実行しないことが判明
- node-ptyは Linux向けのprebuiltバイナリを提供しておらずソースビルドが必要だが、ビルドされていなかった
- node-ptyのディレクトリで直接 `npm run install` を実行することで `node-gyp rebuild` が正しく動作する

## Root Cause Analysis

`node-pty@1.1.0` のinstallスクリプト: `"install": "node scripts/prebuild.js || node-gyp rebuild"`

1. `scripts/prebuild.js`: `prebuilds/linux-arm64` ディレクトリが存在しないため exit 1
2. `node-gyp rebuild` にフォールバックするはずだが...
3. `pnpm rebuild node-pty` はinstallスクリプトを実行しない（pnpm 9のセキュリティポリシー）
4. 結果として `build/Release/pty.node` が生成されず、実行時エラー

検証: `npm run install` をnode-ptyディレクトリで直接実行 → `build/Release/pty.node` が生成される ✓

## Fix

```dockerfile
# Before
RUN pnpm rebuild better-sqlite3 node-pty

# After
RUN pnpm rebuild better-sqlite3
RUN cd node_modules/.pnpm/node-pty@*/node_modules/node-pty && npm run install
```

## Test plan

- [ ] Dockerビルドが成功すること
- [ ] コンテナ起動時に `pty.node` 読み込みエラーが出ないこと
- [ ] ブラウザからアプリにアクセスできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コンテナイメージのビルドプロセスを改善しました。ネイティブモジュールのビルドを分離し、特定の依存に対する個別のインストール／ビルド手順を追加しています。
  * マルチステージビルドの構成は維持されており、公開APIや動作に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->