### PR TITLE
fix: Dockerode Phase 4 - 不要なchild_processモック削除

### DIFF
--- a/src/services/__tests__/session-state-integration.test.ts
+++ b/src/services/__tests__/session-state-integration.test.ts
@@ -113,25 +113,6 @@ vi.mock('fs', async () => {
   }
 })
 
-// child_processモジュールをモック（execAsyncで使用）
-// Docker container検証をスキップするため、execは常に失敗するようにする
-vi.mock('child_process', async () => {
-  const actual = await vi.importActual<typeof import('child_process')>('child_process')
-  const mockExec = vi.fn((cmd, callback) => {
-    // Docker container検証は常に失敗
-    if (callback) {
-      callback(new Error('Command failed'), '', 'Error')
-    }
-  })
-  return {
-    default: {
-      ...actual,
-      exec: mockExec
-    },
-    ...actual,
-    exec: mockExec
-  }
-})
 
 describe('TASK-019: State Management Integration Tests', () => {
   let manager: PTYSessionManager

--- a/src/services/adapters/__tests__/docker-adapter-extension.test.ts
+++ b/src/services/adapters/__tests__/docker-adapter-extension.test.ts
@@ -77,36 +77,6 @@ vi.mock('fs/promises', () => ({
   rm: vi.fn().mockResolvedValue(undefined),
 }));
 
-// child_processのモック
-const { mockExecFile, mockSpawn } = vi.hoisted(() => {
-  const mockExecFileImpl = vi.fn((cmd, args, opts, callback) => {
-    if (!callback) return;
-    process.nextTick(() => {
-      if (args[0] === 'inspect') {
-        callback(null, 'true\n', '');
-      } else if (args[0] === 'exec') {
-        // docker exec のモック（git config, chmod等）
-        callback(null, '', '');
-      } else {
-        callback(null, '', '');
-      }
-    });
-  });
-
-  return {
-    mockExecFile: mockExecFileImpl,
-    mockSpawn: vi.fn(),
-  };
-});
-
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
-  return {
-    ...actual,
-    execFile: mockExecFile,
-    spawn: mockSpawn,
-  };
-});
 
 // ==================== テストスイート ====================
 


### PR DESCRIPTION
## Summary
- session-state-integration.test.ts: 不要なchild_processモック削除
- docker-adapter-extension.test.ts: 不要なchild_processモック削除
- Docker CLIはDockerode経由に移行済みのため、テストからchild_processモックが不要に

## Test plan
- [ ] 対象テスト通過
- [ ] 既存テスト全通過
- [ ] ESLintエラーなし

Related: #144

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * テスト環境のモック設定を簡潔化しました。
  * 特定の外部プロセスのモックを削除し、該当テストの挙動をより実環境に近づけました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->