### PR TITLE
fix: tar-fsモックにdestroy追加とDockerode移行タスク完了ステータス更新

### DIFF
--- a/docs/sdd/dockerode-migration/tasks.md
+++ b/docs/sdd/dockerode-migration/tasks.md
@@ -159,7 +159,7 @@
 
 ### TASK-012: DockerPTYStream アダプタ実装
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #147）
 - **依存**: TASK-001
 - **対象ファイル**:
   - `src/services/docker-pty-stream.ts`: 新規作成
@@ -173,7 +173,7 @@
 
 ### TASK-013: DockerAdapter の docker run -it 移行
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #147）
 - **依存**: TASK-012, TASK-004
 - **対象ファイル**:
   - `src/services/adapters/docker-adapter.ts`: spawnClaudePTY メソッド
@@ -186,7 +186,7 @@
 
 ### TASK-014: DockerAdapter の docker exec -it 移行
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #147）
 - **依存**: TASK-012, TASK-004
 - **対象ファイル**:
   - `src/services/adapters/docker-adapter.ts`: spawnShellPTY メソッド
@@ -196,7 +196,7 @@
 
 ### TASK-015: DockerPTYAdapter の Dockerode 移行
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #147）
 - **依存**: TASK-012
 - **対象ファイル**:
   - `src/services/docker-pty-adapter.ts`
@@ -207,7 +207,7 @@
 
 ### TASK-016: PTY統合テスト（XTerm.js互換性検証）
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #147のCIで検証済み）
 - **依存**: TASK-013, TASK-014, TASK-015
 - **対象ファイル**:
   - インテグレーションテスト
@@ -221,7 +221,7 @@
 
 ### TASK-017: Docker CLI 関連ユーティリティ削除
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（PR #148）
 - **依存**: TASK-016
 - **対象ファイル**:
   - 各サービスファイルから未使用の child_process import 削除
@@ -232,7 +232,7 @@
 
 ### TASK-018: Dockerfile から Docker CLI インストール削除
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（Dockerfileにdocker-ce-cliは元々インストールされていない）
 - **依存**: TASK-017
 - **対象ファイル**:
   - `Dockerfile`: runner ステージから docker-ce-cli 削除（追加されている場合）
@@ -243,7 +243,7 @@
 
 ### TASK-019: 全テスト回帰確認
 
-- **ステータス**: 未着手
+- **ステータス**: 完了（全173ファイル2059テスト通過、lint 0エラー）
 - **依存**: TASK-017, TASK-018
 - **対象ファイル**:
   - 全テストファイル

--- a/src/services/adapters/__tests__/docker-dev-settings.integration.test.ts
+++ b/src/services/adapters/__tests__/docker-dev-settings.integration.test.ts
@@ -82,9 +82,9 @@ vi.mock('node-pty', () => ({
 // Mock tar-fs to prevent real file streaming race conditions
 vi.mock('tar-fs', () => ({
   default: {
-    pack: vi.fn().mockReturnValue({ pipe: vi.fn() }),
+    pack: vi.fn().mockReturnValue({ pipe: vi.fn(), destroy: vi.fn() }),
   },
-  pack: vi.fn().mockReturnValue({ pipe: vi.fn() }),
+  pack: vi.fn().mockReturnValue({ pipe: vi.fn(), destroy: vi.fn() }),
 }));
 
 /**


### PR DESCRIPTION
## Summary
- docker-dev-settings.integration.test.tsのtar-fsモックに`destroy`メソッドを追加し、テスト失敗を修正
- Dockerode移行タスク管理ドキュメント(tasks.md)のPhase 3/4ステータスを全て「完了」に更新

## Changes
- **テスト修正**: tar-fsモックの返却値に`destroy: vi.fn()`を追加。`finally`ブロックの`tarStream.destroy()`呼び出しでTypeErrorが発生し、後続の`chown` exec呼び出しに到達しなかった問題を修正
- **ドキュメント更新**: TASK-012〜019のステータスを完了に更新（PR #147, #148で実装済み）

## Test plan
- [x] docker-dev-settings.integration.test.ts: 7テスト全通過
- [x] 全テスト回帰確認: 173ファイル、2059テスト通過、0失敗
- [x] lint: 0エラー

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 移行タスクの進捗状況を更新しました
  * テスト環境の基盤を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->