### PR TITLE
fix: docker-compose.ymlのポートマッピングをHOST_PORTとPORTに分離

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       dockerfile: Dockerfile
     container_name: claudework
     ports:
-      - "${PORT:-3000}:3000"
+      - "${HOST_PORT:-3000}:3000"
     volumes:
       - ./data:/data
     environment:
       - NODE_ENV=production
       - DATABASE_URL=file:/data/claudework.db
-      - PORT=${PORT:-3000}
+      - PORT=3000
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
       - ALLOWED_PROJECT_DIRS=${ALLOWED_PROJECT_DIRS:-}


### PR DESCRIPTION
## Summary

- docker-compose.ymlでPORT環境変数がホスト側ポートマッピングとコンテナ内部サーバーポートの両方に使われていた問題を修正
- HOST_PORT（ホスト側公開ポート、デフォルト3000）とPORT（コンテナ内部サーバーポート、固定3000）に分離

## 問題

`PORT=3001`を指定すると、ホスト側のポートマッピング(3001:3000)だけでなく、コンテナ内部のサーバーも3001でリッスンしてしまい、Docker内部のポート不整合が発生していた。

## Test plan

- [ ] `docker compose config` で構文確認
- [ ] `HOST_PORT=3001 docker compose up -d` でポート3001で正常にアクセスできることを確認
- [ ] デフォルト（HOST_PORT未指定）でポート3000でアクセスできることを確認

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * デプロイメント設定におけるポート構成を更新しました。ポートバインディング設定をより柔軟に、より明示的に設定するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->