### PR TITLE
fix: ProjectSettingsModalの環境名に環境設定画面へのリンクを追加 (#170)

### DIFF
--- a/src/components/projects/ProjectSettingsModal.tsx
+++ b/src/components/projects/ProjectSettingsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, Fragment, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { Dialog, Transition } from '@headlessui/react';
 import { Project, useAppStore } from '@/store';
 import toast from 'react-hot-toast';
@@ -52,6 +53,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
   const [claudeOptions, setClaudeOptions] = useState<ClaudeCodeOptions>({});
   const [customEnvVars, setCustomEnvVars] = useState<CustomEnvVars>({});
   const [cloneLocation, setCloneLocation] = useState<string | null>(null);
+  const [environmentId, setEnvironmentId] = useState<string | null>(null);
   const [environmentInfo, setEnvironmentInfo] = useState<{ name: string; type: string } | null>(null);
 
   const fetchScripts = useCallback(async (projectId: string) => {
@@ -98,6 +100,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
             setCustomEnvVars({});
           }
           setCloneLocation(proj.clone_location || null);
+          setEnvironmentId(proj.environment_id || null);
           setEnvironmentInfo(proj.environment || null);
         }
       }
@@ -254,6 +257,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     setClaudeOptions({});
     setCustomEnvVars({});
     setCloneLocation(null);
+    setEnvironmentId(null);
     setEnvironmentInfo(null);
     onClose();
   };
@@ -301,14 +305,24 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
                       実行環境
                     </label>
                     <div className="px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md">
-                      <EnvironmentBadge
-                        type={environmentInfo?.type || (cloneLocation === 'docker' ? 'DOCKER' : 'HOST')}
-                        name={environmentInfo
-                          ? environmentInfo.name
-                          : cloneLocation === 'docker'
+                      {environmentId && environmentInfo ? (
+                        <Link
+                          href={`/settings/environments?highlight=${environmentId}`}
+                          className="hover:opacity-80 transition-opacity"
+                        >
+                          <EnvironmentBadge
+                            type={environmentInfo.type}
+                            name={environmentInfo.name}
+                          />
+                        </Link>
+                      ) : (
+                        <EnvironmentBadge
+                          type={cloneLocation === 'docker' ? 'DOCKER' : 'HOST'}
+                          name={cloneLocation === 'docker'
                             ? 'Docker (自動選択)'
                             : 'Host (自動選択)'}
-                      />
+                        />
+                      )}
                     </div>
                     <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                       クローン場所（{cloneLocation || 'host'}）の設定に基づいて自動的に決定されます。プロジェクト作成後に変更することはできません。

--- a/src/components/projects/__tests__/ProjectSettingsModal.test.tsx
+++ b/src/components/projects/__tests__/ProjectSettingsModal.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ProjectSettingsModal - 環境名リンク機能のテスト
+ * Issue#170: プロジェクト設定の環境名から環境設定画面へのリンク追加
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ProjectSettingsModal } from '../ProjectSettingsModal';
+
+// Next.js Link mock
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// store mock
+vi.mock('@/store', () => ({
+  useAppStore: () => ({
+    fetchProjects: vi.fn(),
+  }),
+}));
+
+// react-hot-toast mock
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+// ClaudeOptionsForm mock
+vi.mock('@/components/claude-options/ClaudeOptionsForm', () => ({
+  ClaudeOptionsForm: () => <div data-testid="claude-options-form" />,
+}));
+
+const mockProject = {
+  id: 'project-1',
+  name: 'Test Project',
+  path: '/repos/test',
+  run_scripts: [],
+  session_count: 0,
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+describe('ProjectSettingsModal - 環境名リンク', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('環境IDがある場合、環境名が環境設定画面へのリンクになる', async () => {
+    const environmentId = 'env-123';
+    const environmentName = 'Test Docker';
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scripts: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          project: {
+            clone_location: 'docker',
+            environment_id: environmentId,
+            environment: { id: environmentId, name: environmentName, type: 'DOCKER' },
+            claude_code_options: null,
+            custom_env_vars: null,
+          },
+        }),
+      });
+
+    render(
+      <ProjectSettingsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        project={mockProject}
+      />
+    );
+
+    await waitFor(() => {
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', `/settings/environments?highlight=${environmentId}`);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(environmentName)).toBeInTheDocument();
+    });
+  });
+
+  it('環境IDがない場合(自動選択)、リンクにならない', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scripts: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          project: {
+            clone_location: 'docker',
+            environment_id: null,
+            environment: null,
+            claude_code_options: null,
+            custom_env_vars: null,
+          },
+        }),
+      });
+
+    render(
+      <ProjectSettingsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        project={mockProject}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Docker (自動選択)')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ProjectSettingsModal内の環境名表示をクリック可能なリンクに変更
- 環境IDがある場合、`/settings/environments?highlight={env-id}` へ遷移するLinkコンポーネントでラップ
- 環境IDがない場合(自動選択)は従来通りバッジのみ表示

## Background
Issue #170の実装は`ProjectEnvironmentSettings.tsx`にのみ反映されていたが、実際にプロジェクト設定画面で使用されているのは`ProjectSettingsModal.tsx`であり、こちらにはリンク機能が未実装だった。

## Test plan
- [x] テストファイル作成: `src/components/projects/__tests__/ProjectSettingsModal.test.tsx`
- [x] 環境IDがある場合にリンクが生成されることを確認
- [x] 環境IDがない場合にリンクが表示されないことを確認
- [ ] ブラウザで動作確認: プロジェクト設定モーダルの環境バッジクリックで環境設定画面にジャンプ

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロジェクト設定で環境バッジがクリック可能に。環境が選定されている場合、環境設定ページへのリンクとして機能します。環境が未設定の場合は、Docker/ホストのデフォルトを示すバッジのままです。

* **テスト**
  * プロジェクト設定モーダルの環境名リンク動作に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->