### PR TITLE
feat: Chrome DevTools MCP対応のDockerfileを追加

### DIFF
--- a/docker/Dockerfile.chrome-devtools
+++ b/docker/Dockerfile.chrome-devtools
@@ -1,9 +1,15 @@
 # syntax=docker/dockerfile:1
 # Claude Code Sandboxed Container with Chrome DevTools MCP support
-# Chrome DevTools MCPが動作可能な隔離されたClaude Code実行環境
+# 基本のsandboxイメージを拡張し、Chromiumを追加した実行環境
 #
 # 使用方法:
+#   # リモートの基本イメージを使用（デフォルト）
 #   docker build -f docker/Dockerfile.chrome-devtools -t claude-work-env:chrome-devtools docker/
+#
+#   # ローカルビルドした基本イメージを使用
+#   docker build -f docker/Dockerfile -t claude-work-sandbox:local docker/
+#   docker build -f docker/Dockerfile.chrome-devtools --build-arg BASE_IMAGE=claude-work-sandbox:local \
+#     -t claude-work-env:chrome-devtools docker/
 #
 # MCP設定例 (.mcp.json):
 #   {
@@ -28,20 +34,16 @@
 #   MCP argsに "--chromeArg=--no-sandbox" を追加してください。
 #   sandbox有効化にはホスト側で kernel.unprivileged_userns_clone=1 の設定が必要な場合があります。
 
-FROM node:20-slim
+ARG BASE_IMAGE=ghcr.io/windschord/claude-work-sandbox:latest
+FROM ${BASE_IMAGE}
 
-LABEL maintainer="Claude Work"
 LABEL description="Sandboxed environment for running Claude Code with Chrome DevTools MCP"
 
-# 必要最低限のツール + Chromiumと依存ライブラリをインストール
+# rootに切り替えてChromiumと依存ライブラリをインストール
+USER root
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git \
-        openssh-client \
-        curl \
-        wget \
-        bash \
-        ca-certificates \
         # Chromium本体
         chromium \
         # Chromiumの実行に必要なフォント
@@ -62,44 +64,12 @@ RUN apt-get update \
         libxss1 \
         libxtst6 \
         libdbus-1-3 \
-    && mkdir -p /etc/apt/keyrings \
-    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Codeをインストール
-ARG CLAUDE_CODE_VERSION=2.1.63
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
-
-# nodeユーザーを使用（node:20-slimに既存のUID 1000）
-# /home/claude → /home/node のシンボリックリンク
-RUN test -e /home/claude || ln -s /home/node /home/claude
-
-# SSHディレクトリの準備（マウント用）
-RUN mkdir -p /home/node/.ssh \
-    && chmod 700 /home/node/.ssh \
-    && chown node:node /home/node/.ssh
-
-# Claude設定ディレクトリの準備（マウント用）
-RUN mkdir -p /home/node/.claude /home/node/.config/claude \
-    && chmod 700 /home/node/.claude /home/node/.config/claude \
-    && chown -R node:node /home/node/.claude /home/node/.config
-
-# ワークスペースディレクトリの準備
-RUN mkdir -p /workspace && chown node:node /workspace
-
+# nodeユーザーに戻す
 USER node
-
-ENV HOME=/home/node
-ENV TERM=xterm-256color
-ENV COLORTERM=truecolor
 
 # Chromium/Puppeteer関連の環境変数
 # システムインストール済みChromiumを使用し、Puppeteerによるダウンロードをスキップ
@@ -109,10 +79,3 @@ ENV CHROME_PATH=/usr/bin/chromium
 # /dev/shmサイズ制限の回避（Dockerデフォルト64MBでは不足）
 # --no-sandbox はsandboxが機能しない環境でのみ追加（上部コメント参照）
 ENV CHROMIUM_FLAGS="--disable-dev-shm-usage"
-
-WORKDIR /workspace
-
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD claude --version || exit 1
-
-CMD ["claude"]


### PR DESCRIPTION
## Summary
- Claude Code実行環境(Docker)でChrome DevTools MCPが動作可能な`docker/Dockerfile.chrome-devtools`を新規作成
- 既存の`docker/Dockerfile`は変更なし

## Changes

### docker/Dockerfile.chrome-devtools (新規)
- `node:20-slim`ベースに既存Dockerfileと同等の構成（git, gh, Claude Code等）を維持
- Chromium + 依存ライブラリ（フォント、グラフィクス等）を追加インストール
- Puppeteer/Chrome関連の環境変数を設定（`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`, `CHROME_PATH`等）
- MCP設定例と`--shm-size`推奨値をコメントに記載

### MCP設定例
```json
{
  "mcpServers": {
    "chrome-devtools": {
      "command": "npx",
      "args": [
        "chrome-devtools-mcp@0.12.1",
        "--headless",
        "--isolated",
        "--executablePath=/usr/bin/chromium",
        "--chromeArg=--no-sandbox",
        "--chromeArg=--disable-dev-shm-usage"
      ]
    }
  }
}
```

## Test plan
コンテナをビルドし、内部からMCPプロトコルを使って以下を確認済み:
- [x] Chromiumヘッドレス起動 (v145)
- [x] MCP initialize (chrome_devtools v0.12.1, 26 tools)
- [x] navigate_page (example.comへ遷移)
- [x] take_snapshot (a11yツリー取得)
- [x] take_screenshot (スクリーンショット撮影)
- [x] evaluate_script (JavaScript実行)
- [x] click (リンククリック + ページ遷移)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Chrome DevTools対応のサンドボックス化されたClaude Code実行環境をDockerで提供開始。ローカルでChromiumを利用した開発・デバッグが可能です。

* **その他**
  * コンテナの起動確認やワークスペース構成など、運用に適した設定や環境変数のサポートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->