### PR TITLE
fix: Dockerイメージにpublicディレクトリをコピー

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ COPY --from=deps-prod /app/node_modules ./node_modules
 # ビルド成果物のコピー
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 # 起動スクリプトのコピー（エントリポイントとヘルスチェック）
 COPY --from=builder /app/scripts/docker-entrypoint.sh ./scripts/docker-entrypoint.sh


### PR DESCRIPTION
## Summary

- Dockerfileのrunnerステージで`public/`ディレクトリがコピーされていなかった
- サイドバーのロゴアイコン(`/images/logo-icon.png`)がNext.js Image Optimizationから400エラー(`The requested resource isn't a valid image.`)で返されていた
- `COPY --from=builder /app/public ./public` を追加して修正

## Test plan

- [ ] Dockerイメージをビルドしてコンテナ内に`/app/public/images/logo-icon.png`が存在することを確認
- [ ] ブラウザでサイドバーのロゴアイコンが正常に表示されることを確認
- [ ] `/_next/image?url=%2Fimages%2Flogo-icon.png&w=32&q=75` が200で返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * 本番環境への静的アセット配置を改善しました。ビルドプロセスで生成されたパブリックディレクトリが本番イメージに正しく組み込まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->