### PR TITLE
fix: ConfigServiceのconfigPathにDATA_DIR環境変数を考慮

### DIFF
--- a/docs/sdd/design/global-env-vars.md
+++ b/docs/sdd/design/global-env-vars.md
@@ -62,7 +62,7 @@ if (custom_env_vars !== undefined) {
   const validated = ClaudeOptionsService.validateCustomEnvVars(custom_env_vars);
   if (validated === null) {
     return NextResponse.json(
-      { error: 'Invalid custom_env_vars' },
+      { error: 'custom_env_vars must be a plain object with keys matching ^[A-Z_][A-Z0-9_]*$ and string values' },
       { status: 400 }
     );
   }

--- a/docs/sdd/design/global-env-vars.md
+++ b/docs/sdd/design/global-env-vars.md
@@ -1,0 +1,153 @@
+# 設計書: アプリケーション共通環境変数
+
+## 概要
+
+Application < Project < Session の3階層マージで環境変数を管理する機能。
+ConfigService(`data/settings.json`)にアプリケーション共通の環境変数を保存し、
+Claude Codeセッション起動時にProject/Sessionの環境変数とマージする。
+
+## アーキテクチャ
+
+### データフロー
+
+```
+settings.json (Application) ─┐
+projects.custom_env_vars (Project) ─┤→ mergeEnvVarsAll() → PTY環境変数
+sessions.custom_env_vars (Session) ─┘
+```
+
+### マージ優先順位
+
+```
+Application (最低) < Project < Session (最高)
+```
+
+同一キーの場合、上位レイヤーが下位レイヤーを上書きする。
+
+---
+
+## 変更箇所
+
+### 1. ConfigService (`src/services/config-service.ts`)
+
+`AppConfig` に `custom_env_vars` を追加:
+
+```typescript
+export interface AppConfig {
+  git_clone_timeout_minutes?: number;
+  debug_mode_keep_volumes?: boolean;
+  registry_firewall_enabled?: boolean;
+  custom_env_vars?: Record<string, string>;  // 追加
+}
+```
+
+`DEFAULT_CONFIG` に空オブジェクトを追加:
+
+```typescript
+const DEFAULT_CONFIG: Required<AppConfig> = {
+  // ...既存...
+  custom_env_vars: {},
+};
+```
+
+`load()` と `save()` メソッドで `custom_env_vars` を処理。
+getter `getCustomEnvVars(): Record<string, string>` を追加。
+
+### 2. Settings API (`src/app/api/settings/config/route.ts`)
+
+PUT ハンドラに `custom_env_vars` のバリデーションを追加:
+
+```typescript
+if (custom_env_vars !== undefined) {
+  const validated = ClaudeOptionsService.validateCustomEnvVars(custom_env_vars);
+  if (validated === null) {
+    return NextResponse.json(
+      { error: 'Invalid custom_env_vars' },
+      { status: 400 }
+    );
+  }
+}
+```
+
+### 3. ClaudeOptionsService (`src/services/claude-options-service.ts`)
+
+3階層マージメソッドを追加:
+
+```typescript
+static mergeEnvVarsAll(
+  appEnvVars: CustomEnvVars,
+  projectEnvVars: CustomEnvVars,
+  sessionEnvVars: CustomEnvVars | null
+): CustomEnvVars {
+  return {
+    ...appEnvVars,
+    ...projectEnvVars,
+    ...(sessionEnvVars ?? {}),
+  };
+}
+```
+
+### 4. WebSocket接続時のマージ (`src/lib/websocket/claude-ws.ts`)
+
+既存の2階層マージを3階層に変更:
+
+```typescript
+// Before:
+const mergedEnvVars = ClaudeOptionsService.mergeEnvVars(projectEnvVars, sessionEnvVars);
+
+// After:
+const configService = await ensureConfigLoaded();
+const appEnvVars = configService.getCustomEnvVars();
+const mergedEnvVars = ClaudeOptionsService.mergeEnvVarsAll(
+  appEnvVars, projectEnvVars, sessionEnvVars
+);
+```
+
+### 5. Settings UI (`src/app/settings/app/page.tsx`)
+
+環境変数エディタセクションを追加。既存の `EnvVarEntry` パターンを再利用:
+- KEY/VALUE入力行の追加・削除
+- `^[A-Z_][A-Z0-9_]*$` パターンのクライアントサイドバリデーション
+- 他の設定と同じフォームで一括保存
+
+UIの配置:
+- デバッグモード設定セクションの後(最後のセクション)
+- 保存ボタンは共有(フォーム全体で1つ)
+
+### 6. UI実装の詳細
+
+`EnvVarEditor` コンポーネントを新規作成せず、`page.tsx` にインラインで実装する。
+理由: 既存の `ClaudeOptionsForm.tsx` 内の環境変数エディタは `ClaudeCodeOptions` と結合しており、
+単独で再利用できない。新規コンポーネントを切り出すと過剰な抽象化になる。
+
+状態管理:
+```typescript
+const [envEntries, setEnvEntries] = useState<{ id: string; key: string; value: string }[]>([]);
+```
+
+---
+
+## テスト計画
+
+### ユニットテスト
+
+1. **ConfigService**: `custom_env_vars` の読み書き、デフォルト値
+2. **ClaudeOptionsService.mergeEnvVarsAll()**: 3階層マージの正確性
+3. **Settings API**: `custom_env_vars` のバリデーション(正常系・異常系)
+4. **claude-ws.ts**: Application環境変数がマージに含まれること
+
+### テストファイル
+
+| テスト | ファイル |
+|--------|--------|
+| ConfigService | `src/services/__tests__/config-service.test.ts` |
+| ClaudeOptionsService | `src/services/__tests__/claude-options-service.test.ts` |
+| Settings API | `src/app/api/settings/config/__tests__/route.test.ts` |
+
+---
+
+## 影響範囲の確認
+
+- `data/settings.json` のスキーマ変更(後方互換: 未設定時は `{}`)
+- 既存の Project/Session 環境変数には変更なし
+- DB変更なし

--- a/docs/sdd/design/global-env-vars.md
+++ b/docs/sdd/design/global-env-vars.md
@@ -10,7 +10,7 @@ Claude Codeセッション起動時にProject/Sessionの環境変数とマージ
 
 ### データフロー
 
-```
+```text
 settings.json (Application) ─┐
 projects.custom_env_vars (Project) ─┤→ mergeEnvVarsAll() → PTY環境変数
 sessions.custom_env_vars (Session) ─┘
@@ -18,7 +18,7 @@ sessions.custom_env_vars (Session) ─┘
 
 ### マージ優先順位
 
-```
+```text
 Application (最低) < Project < Session (最高)
 ```
 

--- a/docs/sdd/requirements/global-env-vars.md
+++ b/docs/sdd/requirements/global-env-vars.md
@@ -18,7 +18,7 @@ Claude Codeのメトリクス設定(`CLAUDE_CODE_ENABLE_TELEMETRY`等)など、
 - `sessions.custom_env_vars`(TEXT, JSON文字列)でSession単位の環境変数を管理
 - `ClaudeOptionsService.mergeEnvVars()` で Project → Session のマージを実装済み
 - `ConfigService` が `data/settings.json` でアプリケーション設定を管理
-- Settings画面(`/settings/config`)に設定UI既存
+- Settings画面(`/settings/app`)に設定UI既存
 
 ## DB変更
 

--- a/docs/sdd/requirements/global-env-vars.md
+++ b/docs/sdd/requirements/global-env-vars.md
@@ -1,0 +1,132 @@
+# 要件定義: アプリケーション共通環境変数
+
+## 概要
+
+ClaudeWorkの全プロジェクト・セッションに共通で適用される環境変数設定機能を追加する。
+既存のProject/Session単位の環境変数に加え、Application(共通)レイヤーを追加し、
+3階層マージ(Application < Project < Session)を実現する。
+
+## 背景
+
+Claude Codeのメトリクス設定(`CLAUDE_CODE_ENABLE_TELEMETRY`等)など、
+全環境で共通に設定したい環境変数がある。現状はProject単位でしか設定できず、
+各プロジェクトに個別に設定する必要があり非効率。
+
+## 既存実装の状況
+
+- `projects.custom_env_vars`(TEXT, JSON文字列)でProject単位の環境変数を管理
+- `sessions.custom_env_vars`(TEXT, JSON文字列)でSession単位の環境変数を管理
+- `ClaudeOptionsService.mergeEnvVars()` で Project → Session のマージを実装済み
+- `ConfigService` が `data/settings.json` でアプリケーション設定を管理
+- Settings画面(`/settings/config`)に設定UI既存
+
+## DB変更
+
+なし(既存の `data/settings.json` に `custom_env_vars` フィールドを追加)
+
+---
+
+## 要件定義
+
+### 1. API要件
+
+#### REQ-API-001: アプリケーション共通環境変数の取得
+
+**WHEN** `GET /api/settings/config` が呼び出されるとき、
+**THE SYSTEM SHALL** レスポンスの `config` オブジェクトに `custom_env_vars` フィールドを含める。
+
+受入基準:
+- `config.custom_env_vars` が `Record<string, string>` 形式で返される
+- 未設定時は空オブジェクト `{}` が返される
+- 既存フィールド(`git_clone_timeout_minutes`等)に影響しない
+
+#### REQ-API-002: アプリケーション共通環境変数の更新
+
+**WHEN** `PUT /api/settings/config` が `custom_env_vars` フィールドを含むボディを受け取るとき、
+**THE SYSTEM SHALL** 環境変数をバリデーションし、`data/settings.json` に保存する。
+
+**IF** キーが `^[A-Z_][A-Z0-9_]*$` パターンに一致しない、または値が文字列でない場合、
+**THE SYSTEM SHALL** 400エラーを返す。
+
+受入基準:
+- `custom_env_vars` が `data/settings.json` に永続化される
+- バリデーションは既存の `ClaudeOptionsService.validateCustomEnvVars()` を使用
+- 不正なキー/値で400エラー、エラーメッセージにバリデーション失敗理由を含む
+- `custom_env_vars` 以外のフィールドと独立して更新可能
+
+---
+
+### 2. サービス層要件
+
+#### REQ-SVC-001: 3階層環境変数マージ
+
+**WHEN** Claude Codeセッションの起動時に環境変数をマージするとき、
+**THE SYSTEM SHALL** Application → Project → Session の順でマージし、
+後のレイヤーが前のレイヤーを上書きする。
+
+受入基準:
+- Application共通環境変数がベースとして使用される
+- Project環境変数がApplication共通を上書きする
+- Session環境変数がProject(マージ済み)を上書きする
+- 各レイヤーが空オブジェクトの場合、次のレイヤーにそのまま引き継がれる
+
+#### REQ-SVC-002: ConfigServiceへの環境変数追加
+
+**WHEN** ConfigServiceが設定を読み込み・保存するとき、
+**THE SYSTEM SHALL** `custom_env_vars` フィールドをサポートする。
+
+受入基準:
+- `AppConfig` インターフェースに `custom_env_vars` が追加される
+- デフォルト値は空オブジェクト `{}`
+- `settings.json` への読み書きが正常に動作する
+
+---
+
+### 3. フロントエンド要件
+
+#### REQ-UI-001: Settings画面への環境変数セクション追加
+
+**WHEN** ユーザーが `/settings` 画面を表示するとき、
+**THE SYSTEM SHALL** 「アプリケーション共通環境変数」セクションを表示する。
+
+受入基準:
+- KEY=VALUE形式の入力エディタが表示される
+- 環境変数の追加・編集・削除が可能
+- 保存ボタンで設定が永続化される
+- 既存のProject設定UIと同等の操作性
+
+---
+
+### 4. セキュリティ要件
+
+#### REQ-SEC-001: 環境変数キーのバリデーション
+
+**THE SYSTEM SHALL** 環境変数キーを `^[A-Z_][A-Z0-9_]*$` パターンで検証する。
+
+受入基準:
+- 既存の `ClaudeOptionsService.validateCustomEnvVars()` と同一ルールを適用
+- 不正なキーはAPIレベルで拒否
+
+---
+
+### 5. 非機能要件
+
+#### REQ-NFR-001: 後方互換性
+
+**THE SYSTEM SHALL** 既存のProject/Session環境変数機能に影響を与えない。
+
+受入基準:
+- `custom_env_vars` が未設定の `settings.json` でもエラーなく動作
+- 既存のProject/Session環境変数の動作が変わらない
+
+## 影響範囲
+
+### 変更対象ファイル
+
+| ファイル | 変更内容 |
+|--------|--------|
+| `src/services/config-service.ts` | `AppConfig` に `custom_env_vars` 追加 |
+| `src/app/api/settings/config/route.ts` | `custom_env_vars` のバリデーション・保存 |
+| `src/services/claude-options-service.ts` | 3階層マージメソッド追加 |
+| `src/lib/websocket/claude-ws.ts` | Application環境変数の取得・マージ |
+| Settings画面コンポーネント | 環境変数エディタUI追加 |

--- a/docs/sdd/tasks/global-env-vars.md
+++ b/docs/sdd/tasks/global-env-vars.md
@@ -74,7 +74,7 @@
 
 ## 実行順序
 
-```
+```text
 TASK-F (ドキュメント)
 → TASK-A + TASK-B (並列)
 → TASK-C (API)

--- a/docs/sdd/tasks/global-env-vars.md
+++ b/docs/sdd/tasks/global-env-vars.md
@@ -1,0 +1,83 @@
+# タスク計画: アプリケーション共通環境変数
+
+## タスク一覧
+
+### TASK-A: ConfigService拡張 + テスト
+
+**対象ファイル:**
+- `src/services/config-service.ts`
+- `src/services/__tests__/config-service.test.ts`
+
+**手順(TDD):**
+1. テスト作成: `custom_env_vars` の読み書き、デフォルト値、バリデーション
+2. `AppConfig` に `custom_env_vars: Record<string, string>` を追加
+3. `DEFAULT_CONFIG` に `custom_env_vars: {}` を追加
+4. `load()` / `save()` で `custom_env_vars` を処理
+5. `getCustomEnvVars()` メソッドを追加
+6. テスト通過を確認
+
+### TASK-B: ClaudeOptionsService拡張 + テスト
+
+**対象ファイル:**
+- `src/services/claude-options-service.ts`
+- `src/services/__tests__/claude-options-service.test.ts`
+
+**依存:** なし(TASK-Aと並列可能)
+
+**手順(TDD):**
+1. テスト作成: `mergeEnvVarsAll()` の3階層マージ
+2. `mergeEnvVarsAll()` メソッドを実装
+3. テスト通過を確認
+
+### TASK-C: Settings API拡張 + テスト
+
+**対象ファイル:**
+- `src/app/api/settings/config/route.ts`
+- `src/app/api/settings/config/__tests__/route.test.ts`
+
+**依存:** TASK-A(ConfigServiceの型変更)
+
+**手順(TDD):**
+1. テスト作成: PUT に `custom_env_vars` を含むリクエスト(正常系・バリデーションエラー)
+2. PUT ハンドラに `custom_env_vars` のバリデーション・保存を追加
+3. テスト通過を確認
+
+### TASK-D: WebSocket マージ統合
+
+**対象ファイル:**
+- `src/lib/websocket/claude-ws.ts`
+
+**依存:** TASK-A, TASK-B
+
+**手順:**
+1. `ensureConfigLoaded()` でアプリケーション環境変数を取得
+2. `mergeEnvVars()` を `mergeEnvVarsAll()` に変更
+3. 既存テストの修正(必要な場合)
+
+### TASK-E: Settings UI
+
+**対象ファイル:**
+- `src/app/settings/app/page.tsx`
+
+**依存:** TASK-C(APIが動作すること)
+
+**手順:**
+1. 環境変数エントリの状態管理を追加
+2. KEY/VALUE入力UIを実装(追加・削除ボタン付き)
+3. 保存時にAPI呼び出しに `custom_env_vars` を含める
+4. 読み込み時に `custom_env_vars` を復元
+
+### TASK-F: SDDドキュメントコミット
+
+**手順:**
+1. 要件定義・設計・タスク計画ドキュメントをコミット
+
+## 実行順序
+
+```
+TASK-F (ドキュメント)
+→ TASK-A + TASK-B (並列)
+→ TASK-C (API)
+→ TASK-D (WebSocket統合)
+→ TASK-E (UI)
+```

--- a/src/app/api/settings/config/__tests__/route.test.ts
+++ b/src/app/api/settings/config/__tests__/route.test.ts
@@ -32,6 +32,22 @@ vi.mock('@/lib/logger', () => ({
   },
 }));
 
+vi.mock('@/services/claude-options-service', () => ({
+  ClaudeOptionsService: {
+    validateCustomEnvVars: vi.fn((value: unknown) => {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+      }
+      const obj = value as Record<string, unknown>;
+      for (const [key, val] of Object.entries(obj)) {
+        if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) return null;
+        if (typeof val !== 'string') return null;
+      }
+      return obj as Record<string, string>;
+    }),
+  },
+}));
+
 describe('GET /api/settings/config', () => {
   it('設定を取得できる', async () => {
     const response = await GET();
@@ -357,5 +373,139 @@ describe('PUT /api/settings/config', () => {
     expect(response.status).toBe(500);
     const data = await response.json();
     expect(data.error).toBe('Internal server error');
+  });
+
+  it('valid な custom_env_vars を保存できる', async () => {
+    const { ensureConfigLoaded } = await import('@/services/config-service');
+    const mockSave = vi.fn();
+    vi.mocked(ensureConfigLoaded).mockResolvedValue({
+      getConfig: vi.fn(() => ({
+        git_clone_timeout_minutes: 5,
+        debug_mode_keep_volumes: false,
+        custom_env_vars: { MY_VAR: 'value1', ANOTHER_VAR: 'value2' },
+      })),
+      save: mockSave,
+    } as any);
+
+    const request = new NextRequest('http://localhost/api/settings/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        custom_env_vars: { MY_VAR: 'value1', ANOTHER_VAR: 'value2' },
+      }),
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(200);
+    expect(mockSave).toHaveBeenCalledWith({
+      custom_env_vars: { MY_VAR: 'value1', ANOTHER_VAR: 'value2' },
+    });
+
+    const data = await response.json();
+    expect(data.config.custom_env_vars).toEqual({ MY_VAR: 'value1', ANOTHER_VAR: 'value2' });
+  });
+
+  it('小文字キーを含む custom_env_vars は 400 エラー', async () => {
+    const request = new NextRequest('http://localhost/api/settings/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        custom_env_vars: { my_var: 'value' },
+      }),
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe(
+      'custom_env_vars must be an object with uppercase keys and string values'
+    );
+  });
+
+  it('非文字列値を含む custom_env_vars は 400 エラー', async () => {
+    const request = new NextRequest('http://localhost/api/settings/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        custom_env_vars: { MY_VAR: 123 },
+      }),
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe(
+      'custom_env_vars must be an object with uppercase keys and string values'
+    );
+  });
+
+  it('custom_env_vars が配列の場合は 400 エラー', async () => {
+    const request = new NextRequest('http://localhost/api/settings/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        custom_env_vars: ['MY_VAR=value'],
+      }),
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe(
+      'custom_env_vars must be an object with uppercase keys and string values'
+    );
+  });
+
+  it('custom_env_vars を他のフィールドと独立して更新できる', async () => {
+    const { ensureConfigLoaded } = await import('@/services/config-service');
+    const mockSave = vi.fn();
+    vi.mocked(ensureConfigLoaded).mockResolvedValue({
+      getConfig: vi.fn(() => ({
+        git_clone_timeout_minutes: 5,
+        debug_mode_keep_volumes: false,
+        custom_env_vars: { MY_VAR: 'new_value' },
+      })),
+      save: mockSave,
+    } as any);
+
+    const request = new NextRequest('http://localhost/api/settings/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        custom_env_vars: { MY_VAR: 'new_value' },
+      }),
+    });
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(200);
+    // git_clone_timeout_minutes は含まれないこと
+    expect(mockSave).toHaveBeenCalledWith({
+      custom_env_vars: { MY_VAR: 'new_value' },
+    });
+  });
+});
+
+describe('GET /api/settings/config (custom_env_vars)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET で custom_env_vars が返される', async () => {
+    const { ensureConfigLoaded } = await import('@/services/config-service');
+    vi.mocked(ensureConfigLoaded).mockResolvedValue({
+      getConfig: vi.fn(() => ({
+        git_clone_timeout_minutes: 5,
+        debug_mode_keep_volumes: false,
+        registry_firewall_enabled: true,
+        custom_env_vars: { MY_VAR: 'hello' },
+      })),
+      save: vi.fn(),
+    } as any);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.config.custom_env_vars).toEqual({ MY_VAR: 'hello' });
   });
 });

--- a/src/app/api/settings/config/__tests__/route.test.ts
+++ b/src/app/api/settings/config/__tests__/route.test.ts
@@ -418,7 +418,7 @@ describe('PUT /api/settings/config', () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe(
-      'custom_env_vars must be an object with uppercase keys and string values'
+      'custom_env_vars must be a plain object with keys matching ^[A-Z_][A-Z0-9_]*$ and string values'
     );
   });
 
@@ -435,7 +435,7 @@ describe('PUT /api/settings/config', () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe(
-      'custom_env_vars must be an object with uppercase keys and string values'
+      'custom_env_vars must be a plain object with keys matching ^[A-Z_][A-Z0-9_]*$ and string values'
     );
   });
 
@@ -452,7 +452,7 @@ describe('PUT /api/settings/config', () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe(
-      'custom_env_vars must be an object with uppercase keys and string values'
+      'custom_env_vars must be a plain object with keys matching ^[A-Z_][A-Z0-9_]*$ and string values'
     );
   });
 

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -135,7 +135,11 @@ export async function PUT(request: NextRequest) {
 
     const updatedConfig = configService.getConfig();
 
-    logger.info('Config updated', { config: updatedConfig });
+    const { custom_env_vars: envVarsForLog, ...restForLog } = updatedConfig;
+    const envVarKeys = Object.keys(envVarsForLog ?? {});
+    logger.info('Config updated', {
+      config: { ...restForLog, custom_env_vars: { keys: envVarKeys, count: envVarKeys.length } },
+    });
 
     return NextResponse.json({ config: updatedConfig }, { status: 200 });
   } catch (error) {

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -116,7 +116,7 @@ export async function PUT(request: NextRequest) {
       const validated = ClaudeOptionsService.validateCustomEnvVars(custom_env_vars);
       if (validated === null) {
         return NextResponse.json(
-          { error: 'custom_env_vars must be an object with uppercase keys and string values' },
+          { error: 'custom_env_vars must be a plain object with keys matching ^[A-Z_][A-Z0-9_]*$ and string values' },
           { status: 400 }
         );
       }

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -47,10 +47,10 @@ export async function PUT(request: NextRequest) {
 
     // bodyがplain objectでない場合はエラー
     if (body === null || typeof body !== 'object' || Array.isArray(body)) {
-      logger.warn('Request body must be a plain object', {
+      logger.warn('Request body must be a JSON object', {
         bodyType: Array.isArray(body) ? 'array' : typeof body,
       });
-      return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+      return NextResponse.json({ error: 'Request body must be a JSON object' }, { status: 400 });
     }
 
     const { git_clone_timeout_minutes, debug_mode_keep_volumes, registry_firewall_enabled, claude_defaults, custom_env_vars } = body;

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ensureConfigLoaded } from '@/services/config-service';
 import { validateTimeoutMinutes } from '@/lib/validation';
 import { logger } from '@/lib/logger';
+import { ClaudeOptionsService } from '@/services/claude-options-service';
 
 /**
  * GET /api/settings/config - 設定を取得
@@ -50,7 +51,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
     }
 
-    const { git_clone_timeout_minutes, debug_mode_keep_volumes, registry_firewall_enabled, claude_defaults } = body;
+    const { git_clone_timeout_minutes, debug_mode_keep_volumes, registry_firewall_enabled, claude_defaults, custom_env_vars } = body;
 
     // claude_defaults バリデーション
     if (claude_defaults !== undefined) {
@@ -110,6 +111,16 @@ export async function PUT(request: NextRequest) {
       );
     }
 
+    if (custom_env_vars !== undefined) {
+      const validated = ClaudeOptionsService.validateCustomEnvVars(custom_env_vars);
+      if (validated === null) {
+        return NextResponse.json(
+          { error: 'custom_env_vars must be an object with uppercase keys and string values' },
+          { status: 400 }
+        );
+      }
+    }
+
     // 設定を保存
     const configService = await ensureConfigLoaded();
     await configService.save({
@@ -117,6 +128,7 @@ export async function PUT(request: NextRequest) {
       ...(debug_mode_keep_volumes !== undefined && { debug_mode_keep_volumes }),
       ...(registry_firewall_enabled !== undefined && { registry_firewall_enabled }),
       ...(claude_defaults !== undefined && { claude_defaults }),
+      ...(custom_env_vars !== undefined && { custom_env_vars }),
     });
 
     const updatedConfig = configService.getConfig();

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -111,6 +111,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
+    let validatedEnvVars: Record<string, string> | undefined;
     if (custom_env_vars !== undefined) {
       const validated = ClaudeOptionsService.validateCustomEnvVars(custom_env_vars);
       if (validated === null) {
@@ -119,6 +120,7 @@ export async function PUT(request: NextRequest) {
           { status: 400 }
         );
       }
+      validatedEnvVars = validated;
     }
 
     // 設定を保存
@@ -128,7 +130,7 @@ export async function PUT(request: NextRequest) {
       ...(debug_mode_keep_volumes !== undefined && { debug_mode_keep_volumes }),
       ...(registry_firewall_enabled !== undefined && { registry_firewall_enabled }),
       ...(claude_defaults !== undefined && { claude_defaults }),
-      ...(custom_env_vars !== undefined && { custom_env_vars }),
+      ...(validatedEnvVars !== undefined && { custom_env_vars: validatedEnvVars }),
     });
 
     const updatedConfig = configService.getConfig();

--- a/src/app/api/settings/config/route.ts
+++ b/src/app/api/settings/config/route.ts
@@ -45,9 +45,11 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
     }
 
-    // bodyがnullまたはobjectでない場合はエラー
-    if (body === null || typeof body !== 'object') {
-      logger.warn('Request body must be an object', { body });
+    // bodyがplain objectでない場合はエラー
+    if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+      logger.warn('Request body must be a plain object', {
+        bodyType: Array.isArray(body) ? 'array' : typeof body,
+      });
       return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
     }
 

--- a/src/app/settings/app/page.tsx
+++ b/src/app/settings/app/page.tsx
@@ -2,10 +2,18 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Plus, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BackButton } from '@/components/settings/BackButton';
 import { UnsavedChangesDialog } from '@/components/settings/UnsavedChangesDialog';
+
+interface EnvVarEntry {
+  id: string;
+  key: string;
+  value: string;
+}
+
+const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 interface ClaudeDefaults {
   dangerouslySkipPermissions: boolean;
@@ -16,6 +24,7 @@ interface AppConfig {
   git_clone_timeout_minutes: number;
   debug_mode_keep_volumes: boolean;
   claude_defaults: ClaudeDefaults;
+  custom_env_vars: Record<string, string>;
 }
 
 /**
@@ -34,6 +43,7 @@ export default function AppSettingsPage() {
   const [keepVolumes, setKeepVolumes] = useState(false);
   const [skipPermissions, setSkipPermissions] = useState(false);
   const [worktreeEnabled, setWorktreeEnabled] = useState(true);
+  const [envEntries, setEnvEntries] = useState<EnvVarEntry[]>([]);
 
   // 未保存変更の管理
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -59,6 +69,14 @@ export default function AppSettingsPage() {
         setKeepVolumes(config.debug_mode_keep_volumes ?? false);
         setSkipPermissions(config.claude_defaults?.dangerouslySkipPermissions ?? false);
         setWorktreeEnabled(config.claude_defaults?.worktree ?? true);
+        const envVars: Record<string, string> = config.custom_env_vars ?? {};
+        setEnvEntries(
+          Object.entries(envVars).map(([key, value]) => ({
+            id: crypto.randomUUID(),
+            key,
+            value,
+          }))
+        );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : '設定の取得に失敗しました';
         toast.error(errorMessage);
@@ -85,6 +103,23 @@ export default function AppSettingsPage() {
       return;
     }
 
+    // 環境変数キーのバリデーション
+    const nonEmptyEntries = envEntries.filter((e) => e.key.trim());
+    for (const entry of nonEmptyEntries) {
+      if (!ENV_VAR_KEY_PATTERN.test(entry.key.trim())) {
+        toast.error(`環境変数キー "${entry.key}" が不正です。大文字英字・数字・アンダースコアのみ使用できます。`);
+        return;
+      }
+    }
+
+    // 重複キーチェック
+    const keys = nonEmptyEntries.map((e) => e.key.trim());
+    const duplicates = keys.filter((k, i) => keys.indexOf(k) !== i);
+    if (duplicates.length > 0) {
+      toast.error(`環境変数キー "${duplicates[0]}" が重複しています。`);
+      return;
+    }
+
     setIsSaving(true);
 
     try {
@@ -100,6 +135,11 @@ export default function AppSettingsPage() {
             dangerouslySkipPermissions: skipPermissions,
             worktree: worktreeEnabled,
           },
+          custom_env_vars: Object.fromEntries(
+            envEntries
+              .filter((e) => e.key.trim())
+              .map((e) => [e.key.trim(), e.value])
+          ),
         }),
       });
 
@@ -116,6 +156,14 @@ export default function AppSettingsPage() {
       setKeepVolumes(config?.debug_mode_keep_volumes ?? keepVolumes);
       setSkipPermissions(config?.claude_defaults?.dangerouslySkipPermissions ?? skipPermissions);
       setWorktreeEnabled(config?.claude_defaults?.worktree ?? worktreeEnabled);
+      const savedEnvVars: Record<string, string> = config?.custom_env_vars ?? {};
+      setEnvEntries(
+        Object.entries(savedEnvVars).map(([key, value]) => ({
+          id: crypto.randomUUID(),
+          key,
+          value,
+        }))
+      );
       setHasUnsavedChanges(false); // 保存後にフラグをリセット
       toast.success('設定を保存しました');
     } catch (error) {
@@ -147,6 +195,26 @@ export default function AppSettingsPage() {
   // Worktreeモード変更時の処理
   const handleWorktreeChange = (checked: boolean) => {
     setWorktreeEnabled(checked);
+    setHasUnsavedChanges(true);
+  };
+
+  // 環境変数エントリの追加
+  const handleAddEnvEntry = () => {
+    setEnvEntries((prev) => [...prev, { id: crypto.randomUUID(), key: '', value: '' }]);
+    setHasUnsavedChanges(true);
+  };
+
+  // 環境変数エントリの削除
+  const handleRemoveEnvEntry = (id: string) => {
+    setEnvEntries((prev) => prev.filter((e) => e.id !== id));
+    setHasUnsavedChanges(true);
+  };
+
+  // 環境変数エントリの更新
+  const handleEnvEntryChange = (id: string, field: 'key' | 'value', newValue: string) => {
+    setEnvEntries((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, [field]: newValue } : e))
+    );
     setHasUnsavedChanges(true);
   };
 
@@ -318,6 +386,71 @@ export default function AppSettingsPage() {
               各セッションがClaude Codeの --worktree オプションで分離されます。
             </p>
           </div>
+        </div>
+
+        {/* アプリケーション共通環境変数 */}
+        <div className="mb-6 p-4 bg-white dark:bg-gray-800 rounded-lg shadow">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            アプリケーション共通環境変数
+          </h2>
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+            全プロジェクト・セッションに共通で適用される環境変数を設定します。
+            プロジェクト・セッション単位で同じキーを設定すると上書きされます。
+          </p>
+          <div className="space-y-2">
+            {envEntries.map((entry) => {
+              const normalizedKey = entry.key.trim();
+              const hasKey = normalizedKey.length > 0;
+              const isInvalidKey = hasKey && !ENV_VAR_KEY_PATTERN.test(normalizedKey);
+              const keyLabel = normalizedKey || '未設定';
+
+              return (
+                <div key={entry.id} className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    placeholder="KEY"
+                    aria-label={`環境変数キー ${keyLabel}`}
+                    value={entry.key}
+                    onChange={(e) => handleEnvEntryChange(entry.id, 'key', e.target.value)}
+                    className={`w-1/3 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 font-mono text-sm ${
+                      isInvalidKey
+                        ? 'border-red-500'
+                        : 'border-gray-300 dark:border-gray-600'
+                    }`}
+                    disabled={isSaving || isLoading || _config === null}
+                  />
+                  <span className="text-gray-400">=</span>
+                  <input
+                    type="text"
+                    placeholder="value"
+                    aria-label={`環境変数値 ${keyLabel}`}
+                    value={entry.value}
+                    onChange={(e) => handleEnvEntryChange(entry.id, 'value', e.target.value)}
+                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 font-mono text-sm"
+                    disabled={isSaving || isLoading || _config === null}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveEnvEntry(entry.id)}
+                    className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                    disabled={isSaving || isLoading || _config === null}
+                    aria-label={`環境変数 ${keyLabel} を削除`}
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={handleAddEnvEntry}
+            className="mt-3 flex items-center gap-1 px-3 py-1.5 text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+            disabled={isSaving || isLoading || _config === null}
+          >
+            <Plus className="w-4 h-4" />
+            環境変数を追加
+          </button>
         </div>
 
         {/* 保存ボタン */}

--- a/src/app/settings/app/page.tsx
+++ b/src/app/settings/app/page.tsx
@@ -13,7 +13,7 @@ interface EnvVarEntry {
   value: string;
 }
 
-const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+import { ENV_VAR_KEY_PATTERN } from '@/lib/validation';
 
 function generateId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {

--- a/src/app/settings/app/page.tsx
+++ b/src/app/settings/app/page.tsx
@@ -15,6 +15,13 @@ interface EnvVarEntry {
 
 const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return generateId();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
 interface ClaudeDefaults {
   dangerouslySkipPermissions: boolean;
   worktree: boolean;
@@ -72,7 +79,7 @@ export default function AppSettingsPage() {
         const envVars: Record<string, string> = config.custom_env_vars ?? {};
         setEnvEntries(
           Object.entries(envVars).map(([key, value]) => ({
-            id: crypto.randomUUID(),
+            id: generateId(),
             key,
             value,
           }))
@@ -159,7 +166,7 @@ export default function AppSettingsPage() {
       const savedEnvVars: Record<string, string> = config?.custom_env_vars ?? {};
       setEnvEntries(
         Object.entries(savedEnvVars).map(([key, value]) => ({
-          id: crypto.randomUUID(),
+          id: generateId(),
           key,
           value,
         }))
@@ -200,7 +207,7 @@ export default function AppSettingsPage() {
 
   // 環境変数エントリの追加
   const handleAddEnvEntry = () => {
-    setEnvEntries((prev) => [...prev, { id: crypto.randomUUID(), key: '', value: '' }]);
+    setEnvEntries((prev) => [...prev, { id: generateId(), key: '', value: '' }]);
     setHasUnsavedChanges(true);
   };
 

--- a/src/app/settings/app/page.tsx
+++ b/src/app/settings/app/page.tsx
@@ -114,7 +114,7 @@ export default function AppSettingsPage() {
     const nonEmptyEntries = envEntries.filter((e) => e.key.trim());
     for (const entry of nonEmptyEntries) {
       if (!ENV_VAR_KEY_PATTERN.test(entry.key.trim())) {
-        toast.error(`環境変数キー "${entry.key}" が不正です。大文字英字・数字・アンダースコアのみ使用できます。`);
+        toast.error(`環境変数キー "${entry.key.trim()}" が不正です。先頭は大文字英字またはアンダースコア、以降は大文字英字・数字・アンダースコアのみ使用できます。`);
         return;
       }
     }
@@ -405,18 +405,19 @@ export default function AppSettingsPage() {
             プロジェクト・セッション単位で同じキーを設定すると上書きされます。
           </p>
           <div className="space-y-2">
-            {envEntries.map((entry) => {
+            {envEntries.map((entry, index) => {
               const normalizedKey = entry.key.trim();
               const hasKey = normalizedKey.length > 0;
               const isInvalidKey = hasKey && !ENV_VAR_KEY_PATTERN.test(normalizedKey);
-              const keyLabel = normalizedKey || '未設定';
+              const rowLabel = `${index + 1}行目 ${normalizedKey || '未設定'}`;
 
               return (
                 <div key={entry.id} className="flex items-center gap-2">
                   <input
                     type="text"
                     placeholder="KEY"
-                    aria-label={`環境変数キー ${keyLabel}`}
+                    aria-label={`環境変数キー ${rowLabel}`}
+                    aria-invalid={isInvalidKey}
                     value={entry.key}
                     onChange={(e) => handleEnvEntryChange(entry.id, 'key', e.target.value)}
                     className={`w-1/3 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 font-mono text-sm ${
@@ -430,7 +431,7 @@ export default function AppSettingsPage() {
                   <input
                     type="text"
                     placeholder="value"
-                    aria-label={`環境変数値 ${keyLabel}`}
+                    aria-label={`環境変数値 ${rowLabel}`}
                     value={entry.value}
                     onChange={(e) => handleEnvEntryChange(entry.id, 'value', e.target.value)}
                     className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 font-mono text-sm"
@@ -441,7 +442,7 @@ export default function AppSettingsPage() {
                     onClick={() => handleRemoveEnvEntry(entry.id)}
                     className="p-2 text-gray-400 hover:text-red-500 transition-colors"
                     disabled={isSaving || isLoading || _config === null}
-                    aria-label={`環境変数 ${keyLabel} を削除`}
+                    aria-label={`環境変数 ${rowLabel} を削除`}
                   >
                     <X className="w-4 h-4" />
                   </button>

--- a/src/app/settings/app/page.tsx
+++ b/src/app/settings/app/page.tsx
@@ -17,7 +17,7 @@ const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 function generateId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return generateId();
+    return crypto.randomUUID();
   }
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -3,6 +3,12 @@
  * プロジェクト名、リポジトリURL、cloneLocation、PATのバリデーション
  */
 
+/**
+ * 環境変数キーのバリデーション正規表現
+ * 大文字英字・数字・アンダースコアのみ許可（POSIXの環境変数命名規則に準拠）
+ */
+export const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
 const VALID_PROJECT_NAME = /^[a-zA-Z0-9_-]+$/;
 const MAX_PROJECT_NAME_LENGTH = 255;
 const VALID_GIT_URL = /^(https:\/\/|git@)/;

--- a/src/lib/websocket/__tests__/claude-ws.test.ts
+++ b/src/lib/websocket/__tests__/claude-ws.test.ts
@@ -9,6 +9,7 @@ const {
   mockClaudeOptionsService,
   mockScrollbackBuffer,
   createMockAdapter,
+  mockEnsureConfigLoaded,
 } = vi.hoisted(() => {
   // EventEmitter をモック内で直接使わず、シンプルなモックオブジェクトを使用
   const createMockAdapterFn = () => ({
@@ -76,6 +77,7 @@ const {
       parseEnvVars: vi.fn().mockReturnValue({}),
       mergeOptions: vi.fn().mockReturnValue({}),
       mergeEnvVars: vi.fn().mockReturnValue({}),
+      mergeEnvVarsAll: vi.fn().mockReturnValue({}),
     },
     mockScrollbackBuffer: {
       append: vi.fn(),
@@ -85,6 +87,9 @@ const {
       getByteSize: vi.fn().mockReturnValue(0),
     },
     createMockAdapter: createMockAdapterFn,
+    mockEnsureConfigLoaded: vi.fn().mockResolvedValue({
+      getCustomEnvVars: vi.fn().mockReturnValue({}),
+    }),
   };
 });
 
@@ -125,6 +130,10 @@ vi.mock('@/services/adapter-factory', () => ({
 
 vi.mock('@/services/scrollback-buffer', () => ({
   scrollbackBuffer: mockScrollbackBuffer,
+}));
+
+vi.mock('@/services/config-service', () => ({
+  ensureConfigLoaded: mockEnsureConfigLoaded,
 }));
 
 // ConnectionManagerは実際のインスタンスを使用（モックしない）
@@ -199,6 +208,12 @@ describe('Claude WebSocket Handler - Environment Support', () => {
     mockClaudeOptionsService.parseEnvVars.mockReturnValue({});
     mockClaudeOptionsService.mergeOptions.mockReturnValue({});
     mockClaudeOptionsService.mergeEnvVars.mockReturnValue({});
+    mockClaudeOptionsService.mergeEnvVarsAll.mockReturnValue({});
+
+    // ensureConfigLoadedのモックを再設定（resetAllMocksで壊れるため）
+    mockEnsureConfigLoaded.mockResolvedValue({
+      getCustomEnvVars: vi.fn().mockReturnValue({}),
+    });
 
     // db.update チェーンを再設定（resetAllMocksで壊れるため）
     mockDb.update.mockReturnValue({

--- a/src/lib/websocket/claude-ws.ts
+++ b/src/lib/websocket/claude-ws.ts
@@ -6,6 +6,7 @@ import { db, schema } from '@/lib/db';
 import { eq, asc } from 'drizzle-orm';
 import { logger } from '@/lib/logger';
 import { ClaudeOptionsService } from '@/services/claude-options-service';
+import { ensureConfigLoaded } from '@/services/config-service';
 import type {
   ClaudeErrorMessage,
   ClaudeImageSavedMessage,
@@ -315,7 +316,13 @@ export function setupClaudeWebSocket(
           const sessionEnvVars = ClaudeOptionsService.parseEnvVars(session.custom_env_vars);
 
           const mergedOptions = ClaudeOptionsService.mergeOptions(projectOptions, sessionOptions);
-          const mergedEnvVars = ClaudeOptionsService.mergeEnvVars(projectEnvVars, sessionEnvVars);
+
+          // アプリケーション共通環境変数を取得
+          const configService = await ensureConfigLoaded();
+          const appEnvVars = configService.getCustomEnvVars();
+
+          // 3階層マージ: Application < Project < Session
+          const mergedEnvVars = ClaudeOptionsService.mergeEnvVarsAll(appEnvVars, projectEnvVars, sessionEnvVars);
 
           const hasCustomOptions = Object.keys(mergedOptions).length > 0;
           const hasCustomEnvVars = Object.keys(mergedEnvVars).length > 0;

--- a/src/services/__tests__/claude-options-service.test.ts
+++ b/src/services/__tests__/claude-options-service.test.ts
@@ -389,6 +389,52 @@ describe('ClaudeOptionsService', () => {
     });
   });
 
+  describe('mergeEnvVarsAll', () => {
+    it('should merge all three layers with Session > Project > Application priority', () => {
+      const app: CustomEnvVars = { FOO: 'app', BAR: 'app', BAZ: 'app' };
+      const project: CustomEnvVars = { FOO: 'project', BAR: 'project' };
+      const session: CustomEnvVars = { FOO: 'session' };
+      expect(ClaudeOptionsService.mergeEnvVarsAll(app, project, session)).toEqual({
+        FOO: 'session',
+        BAR: 'project',
+        BAZ: 'app',
+      });
+    });
+
+    it('should return app vars unchanged when only app has values', () => {
+      const app: CustomEnvVars = { FOO: 'app', BAR: 'app' };
+      const project: CustomEnvVars = {};
+      const session: CustomEnvVars = {};
+      expect(ClaudeOptionsService.mergeEnvVarsAll(app, project, session)).toEqual({
+        FOO: 'app',
+        BAR: 'app',
+      });
+    });
+
+    it('should merge app and project when session is null', () => {
+      const app: CustomEnvVars = { FOO: 'app', BAR: 'app' };
+      const project: CustomEnvVars = { FOO: 'project', NEW: 'value' };
+      expect(ClaudeOptionsService.mergeEnvVarsAll(app, project, null)).toEqual({
+        FOO: 'project',
+        BAR: 'app',
+        NEW: 'value',
+      });
+    });
+
+    it('should override lower layers with the same key from upper layers', () => {
+      const app: CustomEnvVars = { KEY: 'from-app' };
+      const project: CustomEnvVars = { KEY: 'from-project' };
+      const session: CustomEnvVars = { KEY: 'from-session' };
+      expect(ClaudeOptionsService.mergeEnvVarsAll(app, project, session)).toEqual({
+        KEY: 'from-session',
+      });
+    });
+
+    it('should return empty object when all layers are empty', () => {
+      expect(ClaudeOptionsService.mergeEnvVarsAll({}, {}, {})).toEqual({});
+    });
+  });
+
   describe('worktree option', () => {
     describe('buildCliArgs', () => {
       it('should add --worktree when worktree is true', () => {

--- a/src/services/__tests__/config-service.test.ts
+++ b/src/services/__tests__/config-service.test.ts
@@ -551,7 +551,7 @@ describe('ConfigService', () => {
       await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
       await configService.load();
 
-      expect(configService.getCustomEnvVars()).toEqual({})
+      expect(configService.getCustomEnvVars()).toEqual({});
     });
   });
 });

--- a/src/services/__tests__/config-service.test.ts
+++ b/src/services/__tests__/config-service.test.ts
@@ -8,6 +8,7 @@ const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
+  debug: vi.fn(),
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -545,13 +546,22 @@ describe('ConfigService', () => {
       expect(configService.getCustomEnvVars()).toEqual({});
     });
 
-    it('値に文字列以外を含むcustom_env_varsはデフォルト値{}になる', async () => {
+    it('全エントリが非文字列値のcustom_env_varsは空{}にフィルタされる', async () => {
       const testConfig = { custom_env_vars: { KEY: 123 } };
       await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
       await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
       await configService.load();
 
       expect(configService.getCustomEnvVars()).toEqual({});
+    });
+
+    it('有効・無効が混在するcustom_env_varsは有効エントリのみ保持される', async () => {
+      const testConfig = { custom_env_vars: { VALID_KEY: 'ok', 'invalid-key': 'ng', NUMERIC: 42 } };
+      await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
+      await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
+      await configService.load();
+
+      expect(configService.getCustomEnvVars()).toEqual({ VALID_KEY: 'ok' });
     });
   });
 });

--- a/src/services/__tests__/config-service.test.ts
+++ b/src/services/__tests__/config-service.test.ts
@@ -482,4 +482,76 @@ describe('ConfigService', () => {
       expect(configService.getRegistryFirewallEnabled()).toBe(true);
     });
   });
+
+  describe('custom_env_vars', () => {
+    it('custom_env_varsが未設定時はデフォルト{}が返される', async () => {
+      await configService.load();
+      expect(configService.getCustomEnvVars()).toEqual({});
+    });
+
+    it('custom_env_varsが設定されている設定ファイルを読み込み、正しく取得できる', async () => {
+      const testConfig = {
+        custom_env_vars: { MY_VAR: 'hello', ANOTHER: 'world' },
+      };
+      await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
+      await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
+      await configService.load();
+
+      expect(configService.getCustomEnvVars()).toEqual({ MY_VAR: 'hello', ANOTHER: 'world' });
+    });
+
+    it('custom_env_varsを含む設定を保存し、ファイルに書き込まれる', async () => {
+      await configService.load();
+      await configService.save({ custom_env_vars: { FOO: 'bar' } });
+
+      const savedContent = await fs.readFile(testConfigPath, 'utf-8');
+      const savedConfig = JSON.parse(savedContent);
+      expect(savedConfig.custom_env_vars).toEqual({ FOO: 'bar' });
+    });
+
+    it('getCustomEnvVars()が正しい値を返す', async () => {
+      await configService.load();
+      await configService.save({ custom_env_vars: { KEY1: 'val1', KEY2: 'val2' } });
+
+      const vars = configService.getCustomEnvVars();
+      expect(vars).toEqual({ KEY1: 'val1', KEY2: 'val2' });
+    });
+
+    it('getCustomEnvVars()が返すオブジェクトは独立したコピーである', async () => {
+      await configService.load();
+      await configService.save({ custom_env_vars: { KEY: 'value' } });
+
+      const vars1 = configService.getCustomEnvVars();
+      const vars2 = configService.getCustomEnvVars();
+      expect(vars1).not.toBe(vars2);
+      expect(vars1).toEqual(vars2);
+    });
+
+    it('不正なcustom_env_vars(配列)の場合にデフォルト値{}になる', async () => {
+      const testConfig = { custom_env_vars: ['not', 'an', 'object'] };
+      await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
+      await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
+      await configService.load();
+
+      expect(configService.getCustomEnvVars()).toEqual({});
+    });
+
+    it('不正なcustom_env_vars(null)の場合にデフォルト値{}になる', async () => {
+      const testConfig = { custom_env_vars: null };
+      await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
+      await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
+      await configService.load();
+
+      expect(configService.getCustomEnvVars()).toEqual({});
+    });
+
+    it('値に文字列以外を含むcustom_env_varsはデフォルト値{}になる', async () => {
+      const testConfig = { custom_env_vars: { KEY: 123 } };
+      await fs.mkdir(path.dirname(testConfigPath), { recursive: true });
+      await fs.writeFile(testConfigPath, JSON.stringify(testConfig), 'utf-8');
+      await configService.load();
+
+      expect(configService.getCustomEnvVars()).toEqual({})
+    });
+  });
 });

--- a/src/services/claude-options-service.ts
+++ b/src/services/claude-options-service.ts
@@ -1,3 +1,5 @@
+import { ENV_VAR_KEY_PATTERN } from '@/lib/validation';
+
 /**
  * Claude Code CLIオプション設定
  */
@@ -16,12 +18,6 @@ export interface ClaudeCodeOptions {
 export interface CustomEnvVars {
   [key: string]: string;
 }
-
-/**
- * 環境変数キーのバリデーション正規表現
- * 大文字英字・数字・アンダースコアのみ許可（POSIXの環境変数命名規則に準拠）
- */
-const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 /**
  * 制御文字を検出する正規表現（RegExpコンストラクタで定義）

--- a/src/services/claude-options-service.ts
+++ b/src/services/claude-options-service.ts
@@ -87,6 +87,22 @@ export class ClaudeOptionsService {
   }
 
   /**
+   * アプリケーション共通・プロジェクト・セッションの環境変数を3階層でマージ
+   * 優先順位: Application < Project < Session
+   */
+  static mergeEnvVarsAll(
+    appEnvVars: CustomEnvVars,
+    projectEnvVars: CustomEnvVars,
+    sessionEnvVars: CustomEnvVars | null
+  ): CustomEnvVars {
+    return {
+      ...appEnvVars,
+      ...projectEnvVars,
+      ...(sessionEnvVars ?? {}),
+    };
+  }
+
+  /**
    * プロジェクトデフォルトとセッション固有環境変数をマージ
    * セッション固有環境変数がプロジェクトデフォルトをオーバーライド
    */

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '@/lib/logger';
 import { ENV_VAR_KEY_PATTERN } from '@/lib/validation';
+import { getDataDir } from '@/lib/data-dir';
 
 /**
  * Claude Codeのデフォルト設定
@@ -84,7 +85,7 @@ export class ConfigService {
   private configPath: string;
 
   constructor(configPath?: string) {
-    this.configPath = configPath || path.join(process.cwd(), 'data', 'settings.json');
+    this.configPath = configPath || path.join(getDataDir(), 'settings.json');
     this.config = cloneConfig(DEFAULT_CONFIG);
   }
 

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,12 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '@/lib/logger';
-
-/**
- * 環境変数キーのバリデーション正規表現
- * ClaudeOptionsService.ENV_VAR_KEY_PATTERN と同一ルール
- */
-const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+import { ENV_VAR_KEY_PATTERN } from '@/lib/validation';
 
 /**
  * Claude Codeのデフォルト設定

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -48,6 +48,17 @@ const cloneConfig = (config: Required<AppConfig>): Required<AppConfig> => ({
 });
 
 /**
+ * ログ出力用に custom_env_vars の値をマスクした設定オブジェクトを返す
+ */
+function sanitizeConfigForLog(config: Required<AppConfig>): Record<string, unknown> {
+  const { custom_env_vars, ...rest } = config;
+  return {
+    ...rest,
+    custom_env_vars: { keys: Object.keys(custom_env_vars), count: Object.keys(custom_env_vars).length },
+  };
+}
+
+/**
  * ConfigService
  * アプリケーション設定の管理
  */
@@ -107,7 +118,7 @@ export class ConfigService {
         custom_env_vars: validatedCustomEnvVars,
       };
 
-      logger.info('Configuration loaded', { config: this.config });
+      logger.info('Configuration loaded', { config: sanitizeConfigForLog(this.config) });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         logger.info('Configuration file not found, using defaults', { configPath: this.configPath });
@@ -145,7 +156,7 @@ export class ConfigService {
         'utf-8'
       );
 
-      logger.info('Configuration saved', { config: this.config });
+      logger.info('Configuration saved', { config: sanitizeConfigForLog(this.config) });
     } catch (error) {
       logger.error('Failed to save configuration', { error });
       throw new Error('Failed to save configuration');

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -75,6 +75,7 @@ export class ConfigService {
         typeof rawCustomEnvVars === 'object' &&
         !Array.isArray(rawCustomEnvVars)
       ) {
+        // キーパターン検証: ^[A-Z_][A-Z0-9_]*$ に一致し、値が文字列のもののみ採用
         const keyPattern = /^[A-Z_][A-Z0-9_]*$/;
         const filtered: Record<string, string> = {};
         for (const [key, value] of Object.entries(rawCustomEnvVars)) {

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -52,9 +52,10 @@ const cloneConfig = (config: Required<AppConfig>): Required<AppConfig> => ({
  */
 function sanitizeConfigForLog(config: Required<AppConfig>): Record<string, unknown> {
   const { custom_env_vars, ...rest } = config;
+  const keys = Object.keys(custom_env_vars);
   return {
     ...rest,
-    custom_env_vars: { keys: Object.keys(custom_env_vars), count: Object.keys(custom_env_vars).length },
+    custom_env_vars: { keys, count: keys.length },
   };
 }
 
@@ -91,6 +92,8 @@ export class ConfigService {
         for (const [key, value] of Object.entries(rawCustomEnvVars)) {
           if (ClaudeOptionsService.validateEnvVarKey(key) && typeof value === 'string') {
             filtered[key] = value;
+          } else {
+            logger.debug('Invalid custom_env_var entry skipped', { key, valueType: typeof value });
           }
         }
         validatedCustomEnvVars = filtered;

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,7 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '@/lib/logger';
-import { ClaudeOptionsService } from '@/services/claude-options-service';
+
+/**
+ * 環境変数キーのバリデーション正規表現
+ * ClaudeOptionsService.ENV_VAR_KEY_PATTERN と同一ルール
+ */
+const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 /**
  * Claude Codeのデフォルト設定
@@ -19,6 +24,7 @@ export interface AppConfig {
   debug_mode_keep_volumes?: boolean;
   registry_firewall_enabled?: boolean;
   claude_defaults?: ClaudeDefaults;
+  /** Application層の共通環境変数。Project・Sessionで同キーを設定すると上書きされる（優先順位最低） */
   custom_env_vars?: Record<string, string>;
 }
 
@@ -90,7 +96,7 @@ export class ConfigService {
       ) {
         const filtered: Record<string, string> = {};
         for (const [key, value] of Object.entries(rawCustomEnvVars)) {
-          if (ClaudeOptionsService.validateEnvVarKey(key) && typeof value === 'string') {
+          if (ENV_VAR_KEY_PATTERN.test(key) && typeof value === 'string') {
             filtered[key] = value;
           } else {
             logger.debug('Invalid custom_env_var entry skipped', { key, valueType: typeof value });
@@ -138,8 +144,12 @@ export class ConfigService {
    */
   async save(config: Partial<AppConfig>): Promise<void> {
     try {
-      // 既存の設定とマージ（claude_defaultsはネストマージ）
-      const { claude_defaults: newClaudeDefaults, ...rest } = config;
+      // 既存の設定とマージ（ネストオブジェクトは個別にマージ）
+      const {
+        claude_defaults: newClaudeDefaults,
+        custom_env_vars: newCustomEnvVars,
+        ...rest
+      } = config;
       this.config = {
         ...this.config,
         ...rest,
@@ -147,6 +157,10 @@ export class ConfigService {
           ...this.config.claude_defaults,
           ...(newClaudeDefaults || {}),
         },
+        custom_env_vars:
+          newCustomEnvVars === undefined
+            ? { ...this.config.custom_env_vars }
+            : { ...newCustomEnvVars },
       };
 
       // ディレクトリが存在しない場合は作成
@@ -205,7 +219,8 @@ export class ConfigService {
   }
 
   /**
-   * カスタム環境変数を取得
+   * Application層の共通環境変数を取得
+   * マージ優先順位: Application(本値) < Project < Session
    */
   getCustomEnvVars(): Record<string, string> {
     return { ...this.config.custom_env_vars };

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '@/lib/logger';
+import { ClaudeOptionsService } from '@/services/claude-options-service';
 
 /**
  * Claude Codeのデフォルト設定
@@ -69,17 +70,15 @@ export class ConfigService {
 
       // custom_env_vars の検証: plain objectからキーパターン一致かつ値が文字列のエントリのみフィルタ採用
       const rawCustomEnvVars = loadedConfig.custom_env_vars;
-      let validatedCustomEnvVars: Record<string, string> = DEFAULT_CONFIG.custom_env_vars;
+      let validatedCustomEnvVars: Record<string, string> = {};
       if (
         rawCustomEnvVars !== null &&
         typeof rawCustomEnvVars === 'object' &&
         !Array.isArray(rawCustomEnvVars)
       ) {
-        // キーパターン検証: ^[A-Z_][A-Z0-9_]*$ に一致し、値が文字列のもののみ採用
-        const keyPattern = /^[A-Z_][A-Z0-9_]*$/;
         const filtered: Record<string, string> = {};
         for (const [key, value] of Object.entries(rawCustomEnvVars)) {
-          if (keyPattern.test(key) && typeof value === 'string') {
+          if (ClaudeOptionsService.validateEnvVarKey(key) && typeof value === 'string') {
             filtered[key] = value;
           }
         }

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -49,6 +49,21 @@ const cloneConfig = (config: Required<AppConfig>): Required<AppConfig> => ({
 });
 
 /**
+ * 環境変数エントリからキーパターン一致かつ値が文字列のもののみを返す
+ */
+function filterValidEnvVars(vars: Record<string, unknown>): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    if (ENV_VAR_KEY_PATTERN.test(key) && typeof value === 'string') {
+      filtered[key] = value;
+    } else {
+      logger.debug('Invalid custom_env_var entry skipped', { key, valueType: typeof value });
+    }
+  }
+  return filtered;
+}
+
+/**
  * ログ出力用に custom_env_vars の値をマスクした設定オブジェクトを返す
  */
 function sanitizeConfigForLog(config: Required<AppConfig>): Record<string, unknown> {
@@ -89,15 +104,7 @@ export class ConfigService {
         typeof rawCustomEnvVars === 'object' &&
         !Array.isArray(rawCustomEnvVars)
       ) {
-        const filtered: Record<string, string> = {};
-        for (const [key, value] of Object.entries(rawCustomEnvVars)) {
-          if (ENV_VAR_KEY_PATTERN.test(key) && typeof value === 'string') {
-            filtered[key] = value;
-          } else {
-            logger.debug('Invalid custom_env_var entry skipped', { key, valueType: typeof value });
-          }
-        }
-        validatedCustomEnvVars = filtered;
+        validatedCustomEnvVars = filterValidEnvVars(rawCustomEnvVars as Record<string, unknown>);
       }
 
       // デフォルト値とマージ
@@ -136,6 +143,8 @@ export class ConfigService {
 
   /**
    * 設定ファイルを保存する
+   * claude_defaults: 部分更新(既存キーとマージ)
+   * custom_env_vars: 完全置換(提供時は既存キーを全て上書き、undefinedなら既存を保持)
    */
   async save(config: Partial<AppConfig>): Promise<void> {
     try {
@@ -155,7 +164,7 @@ export class ConfigService {
         custom_env_vars:
           newCustomEnvVars === undefined
             ? { ...this.config.custom_env_vars }
-            : { ...newCustomEnvVars },
+            : filterValidEnvVars(newCustomEnvVars),
       };
 
       // ディレクトリが存在しない場合は作成

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -18,6 +18,7 @@ export interface AppConfig {
   debug_mode_keep_volumes?: boolean;
   registry_firewall_enabled?: boolean;
   claude_defaults?: ClaudeDefaults;
+  custom_env_vars?: Record<string, string>;
 }
 
 /**
@@ -33,14 +34,16 @@ const DEFAULT_CONFIG: Required<AppConfig> = {
   debug_mode_keep_volumes: false,
   registry_firewall_enabled: true,
   claude_defaults: { ...DEFAULT_CLAUDE_DEFAULTS },
+  custom_env_vars: {},
 };
 
 /**
- * ネストオブジェクト(claude_defaults)を含む設定のdeep copy
+ * ネストオブジェクト(claude_defaults, custom_env_vars)を含む設定のdeep copy
  */
 const cloneConfig = (config: Required<AppConfig>): Required<AppConfig> => ({
   ...config,
   claude_defaults: { ...config.claude_defaults },
+  custom_env_vars: { ...config.custom_env_vars },
 });
 
 /**
@@ -64,6 +67,24 @@ export class ConfigService {
       const fileContent = await fs.readFile(this.configPath, 'utf-8');
       const loadedConfig = JSON.parse(fileContent) as AppConfig;
 
+      // custom_env_vars の検証: plain objectからキーパターン一致かつ値が文字列のエントリのみフィルタ採用
+      const rawCustomEnvVars = loadedConfig.custom_env_vars;
+      let validatedCustomEnvVars: Record<string, string> = DEFAULT_CONFIG.custom_env_vars;
+      if (
+        rawCustomEnvVars !== null &&
+        typeof rawCustomEnvVars === 'object' &&
+        !Array.isArray(rawCustomEnvVars)
+      ) {
+        const keyPattern = /^[A-Z_][A-Z0-9_]*$/;
+        const filtered: Record<string, string> = {};
+        for (const [key, value] of Object.entries(rawCustomEnvVars)) {
+          if (keyPattern.test(key) && typeof value === 'string') {
+            filtered[key] = value;
+          }
+        }
+        validatedCustomEnvVars = filtered;
+      }
+
       // デフォルト値とマージ
       const loadedClaudeDefaults = loadedConfig.claude_defaults;
       this.config = {
@@ -83,6 +104,7 @@ export class ConfigService {
               ? loadedClaudeDefaults.worktree
               : DEFAULT_CLAUDE_DEFAULTS.worktree,
         },
+        custom_env_vars: validatedCustomEnvVars,
       };
 
       logger.info('Configuration loaded', { config: this.config });
@@ -166,6 +188,13 @@ export class ConfigService {
       dangerouslySkipPermissions: this.config.claude_defaults.dangerouslySkipPermissions ?? DEFAULT_CLAUDE_DEFAULTS.dangerouslySkipPermissions,
       worktree: this.config.claude_defaults.worktree ?? DEFAULT_CLAUDE_DEFAULTS.worktree,
     };
+  }
+
+  /**
+   * カスタム環境変数を取得
+   */
+  getCustomEnvVars(): Record<string, string> {
+    return { ...this.config.custom_env_vars };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Docker環境で`settings.json`の保存に失敗する問題を修正
- `process.cwd()/data/`の代わりに`getDataDir()`を使用してDATA_DIR環境変数を考慮

## Root Cause

ConfigServiceのデフォルトパスが`process.cwd() + '/data/settings.json'`だったが、
Docker内では`DATA_DIR=/data`が設定されており、データは`/data/`にマウントされている。
`/app/data/`は存在しないため、設定の保存に失敗していた。

## Test plan

- [x] config-service.test.ts 51テスト全通過
- [ ] Docker Composeでデプロイして環境変数の保存を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アプリケーション全体で使用できるカスタム環境変数機能を追加しました。
  * 設定画面にアプリケーション共通環境変数エディターを追加し、環境変数の追加・編集・削除が可能になりました。
  * アプリケーション、プロジェクト、セッションの3層での環境変数マージに対応し、上位層の設定が下位層を上書きするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->