### PR TITLE
fix: ConfigServiceのconfigPathにDATA_DIR環境変数を考慮

### DIFF
--- a/src/services/__tests__/config-service.test.ts
+++ b/src/services/__tests__/config-service.test.ts
@@ -564,4 +564,34 @@ describe('ConfigService', () => {
       expect(configService.getCustomEnvVars()).toEqual({ VALID_KEY: 'ok' });
     });
   });
+
+  describe('DATA_DIR対応', () => {
+    it('DATA_DIR環境変数が設定されている場合、そのディレクトリにsettings.jsonを保存する', async () => {
+      const dataDirPath = path.join(tmpdir(), `data-dir-test-${Date.now()}`);
+      await fs.mkdir(dataDirPath, { recursive: true });
+      const originalDataDir = process.env.DATA_DIR;
+
+      try {
+        process.env.DATA_DIR = dataDirPath;
+        // 引数なしでConfigServiceを生成（DATA_DIRを使用するはず）
+        const service = new ConfigService();
+        await service.load();
+        await service.save({ git_clone_timeout_minutes: 15 });
+
+        // DATA_DIR配下にsettings.jsonが作成されていること
+        const savedPath = path.join(dataDirPath, 'settings.json');
+        const content = await fs.readFile(savedPath, 'utf-8');
+        const saved = JSON.parse(content);
+        expect(saved.git_clone_timeout_minutes).toBe(15);
+      } finally {
+        // 環境変数を復元
+        if (originalDataDir !== undefined) {
+          process.env.DATA_DIR = originalDataDir;
+        } else {
+          delete process.env.DATA_DIR;
+        }
+        await fs.rm(dataDirPath, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '@/lib/logger';
 import { ENV_VAR_KEY_PATTERN } from '@/lib/validation';
+import { getDataDir } from '@/lib/data-dir';
 
 /**
  * Claude Codeのデフォルト設定
@@ -84,7 +85,8 @@ export class ConfigService {
   private configPath: string;
 
   constructor(configPath?: string) {
-    this.configPath = configPath || path.join(process.cwd(), 'data', 'settings.json');
+    // DATA_DIR環境変数を考慮（Docker環境では/data/にマウントされる）
+    this.configPath = configPath || path.join(getDataDir(), 'settings.json');
     this.config = cloneConfig(DEFAULT_CONFIG);
   }
 


### PR DESCRIPTION
## Summary

- Docker環境で`settings.json`の保存に失敗する問題を修正
- `process.cwd()/data/`の代わりに`getDataDir()`を使用してDATA_DIR環境変数を考慮

## Root Cause

ConfigServiceのデフォルトパスが`process.cwd() + '/data/settings.json'`だったが、
Docker内では`DATA_DIR=/data`が設定されており、データは`/data/`にマウントされている。
`/app/data/`は存在しないため、設定の保存に失敗していた。

## Test plan

- [x] config-service.test.ts 51テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **その他の改善**
  * 設定ファイルのデフォルト保存先をアプリのデータディレクトリに変更しました。
* **テスト**
  * 環境変数で指定したデータディレクトリを使う挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->